### PR TITLE
Treat checkbox inputs with no values as toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The following types are currently supported:
 | `<input {...input.tel(name: string) />`                     | `{ [name: string]: string }`        |
 | `<input {...input.radio(name: string, value: string) />`    | `{ [name: string]: string }`        |
 | `<input {...input.checkbox(name: string, value: string) />` | `{ [name: string]: Array<string> }` |
+| `<input {...input.checkbox(name: string) />`                | `{ [name: string]: boolean }`       |
 | `<input {...input.date(name: string) />`                    | `{ [name: string]: string }`        |
 | `<input {...input.month(name: string) />`                   | `{ [name: string]: string }`        |
 | `<input {...input.week(name: string) />`                    | `{ [name: string]: string }`        |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "dist"
   ],
   "jest": {
+    "watchPathIgnorePatterns": [
+      "dist"
+    ],
     "collectCoverageFrom": [
       "src/**"
     ],

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-use-form-state 0.2
+// Type definitions for react-use-form-state 0.3
 // Project: https://github.com/wsmd/react-use-form-state
 // Definitions by: Waseem Dahman <https://github.com/wsmd>
 
@@ -24,7 +24,16 @@ interface Inputs {
   range(name: string): InputProps;
   tel(name: string): InputProps;
   radio(name: string, value: string): InputProps & CheckedProp;
+  /**
+   * Checkbox inputs with a value will be treated as a collection of choices.
+   * Their values in in the form state will be of type Array<string>
+   */
   checkbox(name: string, value: string): InputProps & CheckedProp;
+  /**
+   * Checkbox inputs without a value will be treated as toggles. Their values in
+   * in the form state will be of type boolean
+   */
+  checkbox(name: string): InputProps & CheckedProp;
   date(name: string): InputProps;
   month(name: string): InputProps;
   week(name: string): InputProps;

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -37,7 +37,7 @@ export default function useFormState(initialState) {
           if (hasOwnValue) {
             /**
              * @todo Handle the case where two checkbox inputs share the same
-             * name, but one with a value, and the other doesn't (throws currently).
+             * name, but one has a value, the other doesn't (throws currently).
              * <input {...input.checkbox('option1')} />
              * <input {...input.checkbox('option1', 'value_of_option1')} />
              */

--- a/test/userFormState.test.js
+++ b/test/userFormState.test.js
@@ -109,6 +109,20 @@ describe('type methods return correct props object', () => {
   });
 
   /**
+   * Checkbox must have a type, value, and checked
+   */
+  it('returns props for type "checkbox" without a value', () => {
+    const [, input] = useFormState();
+    expect(input.checkbox('option')).toEqual({
+      type: 'checkbox',
+      name: 'option',
+      checked: expect.any(Boolean),
+      onChange: expect.any(Function),
+      onBlur: expect.any(Function),
+    });
+  });
+
+  /**
    * Radio must have a type, value, and checked
    */
   it('returns props for type "radio"', () => {
@@ -170,6 +184,15 @@ describe('inputs receive default values from initial state', () => {
     expect(input.checkbox('options', 'option_3').checked).toEqual(false);
   });
 
+  it('sets initiate "checked" for type "checkbox" without a value', () => {
+    const initialState = { option1: true };
+    const [, input] = useFormState(initialState);
+    expect(input.checkbox('option1').checked).toEqual(true);
+    expect(input.checkbox('option1').value).toEqual(undefined);
+    expect(input.checkbox('option2').checked).toEqual(false);
+    expect(input.checkbox('option2').value).toEqual(undefined);
+  });
+
   it('sets initiate "checked" for type "radio"', () => {
     const [, input] = useFormState({ option: 'no' });
     expect(input.radio('option', 'yes').checked).toEqual(false);
@@ -214,6 +237,15 @@ describe('onChange updates inputs value', () => {
     expect(state[name]).toEqual([value]);
     input.checkbox(name, value).onChange({ target: { value, checked: false } });
     expect(state[name]).toEqual([]);
+  });
+
+  it('updates value for type "checkbox" without a value', () => {
+    const [, input] = useFormState();
+    const name = 'checkbox-input';
+    input.checkbox(name).onChange({ target: { checked: true } });
+    expect(state[name]).toEqual(true);
+    input.checkbox(name).onChange({ target: { checked: false } });
+    expect(state[name]).toEqual(false);
   });
 
   it('updates value for type "radio"', () => {


### PR DESCRIPTION
It would be nice to treat checkboxes without values as toggles (booleans), and ones with values as a collection of options.

**Before**

```jsx
<input {...checkbox('body_type', 'sedan')} />
<input {...checkbox('body_type', 'suv')} />
<input {...checkbox('body_type', 'van')} />

// formState
{
  "body_type": ["sedan", "suv", "van"]
}
```

```jsx
<input {...checkbox('remember_me')} />

// formState
{
  "remember_me": [""]
}
```

**After**

```jsx
<input {...checkbox('body_type', 'sedan')} />
<input {...checkbox('body_type', 'suv')} />
<input {...checkbox('body_type', 'van')} />

// formState
{
  "body_type": ["sedan", "suv", "van"]
}
```

```jsx
<input {...checkbox('remember_me')} /> 

// formState
{
  "remember_me": true
}
```