### PR TITLE
Add support for textarea

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ The following types are currently supported:
 
 | Type and Usage                                              | State Shape                         |
 | ----------------------------------------------------------- | ----------------------------------- |
-| `<select {...input.select(name: string) />`                 | `{ [name: string]: string }`        |
 | `<input {...input.email(name: string) />`                   | `{ [name: string]: string }`        |
 | `<input {...input.color(name: string) />`                   | `{ [name: string]: string }`        |
 | `<input {...input.password(name: string) />`                | `{ [name: string]: string }`        |
@@ -202,6 +201,9 @@ The following types are currently supported:
 | `<input {...input.month(name: string) />`                   | `{ [name: string]: string }`        |
 | `<input {...input.week(name: string) />`                    | `{ [name: string]: string }`        |
 | `<input {...input.time(name: string) />`                    | `{ [name: string]: string }`        |
+| `<select {...input.select(name: string) />`                 | `{ [name: string]: string }`        |
+| `<textarea {...input.textarea(name: string) />`             | `{ [name: string]: string }`        |
+
 
 ## License
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,7 @@ export const SEARCH = 'search';
 export const SELECT = 'select';
 export const TEL = 'tel';
 export const TEXT = 'text';
+export const TEXTAREA = 'textarea';
 export const TIME = 'time';
 export const URL = 'url';
 export const WEEK = 'week';
@@ -37,6 +38,7 @@ export const TYPES = [
   SELECT,
   TEL,
   TEXT,
+  TEXTAREA,
   TIME,
   URL,
   WEEK,

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -1,6 +1,6 @@
 import { useReducer } from 'react';
 import stateReducer from './stateReducer';
-import { TYPES, SELECT, CHECKBOX, RADIO } from './constants';
+import { TYPES, SELECT, CHECKBOX, RADIO, TEXTAREA } from './constants';
 
 export default function useFormState(initialState) {
   const [state, setState] = useReducer(stateReducer, initialState || {});
@@ -42,7 +42,7 @@ export default function useFormState(initialState) {
     const inputProps = {
       name,
       get type() {
-        if (type !== SELECT) return type;
+        if (type !== SELECT && type !== TEXTAREA) return type;
       },
       get checked() {
         if (isRadio) {

--- a/test/userFormState.test.js
+++ b/test/userFormState.test.js
@@ -24,6 +24,7 @@ describe('useFormState API', () => {
     'color',
     'radio',
     'select',
+    'textarea',
   ])('has a method for type "%s"', type => {
     const result = useFormState();
     expect(result[1][type]).toBeInstanceOf(Function);
@@ -116,12 +117,25 @@ describe('input type methods return correct props object', () => {
       onBlur: expect.any(Function),
     });
   });
+
+  /**
+   * Textarea doesn't need a type
+   */
+  it('returns props from type "textarea"', () => {
+    const [, input] = useFormState();
+    expect(input.textarea('name')).toEqual({
+      name: 'name',
+      value: '',
+      onChange: expect.any(Function),
+      onBlur: expect.any(Function),
+    });
+  });
 });
 
 describe('inputs receive default values from initial state', () => {
   mockReactUseReducer();
 
-  it.each([...textLikeInputs, ...timeInputs, 'color'])(
+  it.each([...textLikeInputs, ...timeInputs, 'color', 'textarea'])(
     'sets initial "value" for type "%s"',
     type => {
       const initialState = { 'input-name': 'input-value' };
@@ -161,11 +175,14 @@ describe('inputs receive default values from initial state', () => {
 });
 
 describe('onChange updates inputs value', () => {
-  it.each(textLikeInputs)('updates value for type "%s"', type => {
-    const { change, input } = renderInput(type, 'input-name');
-    change({ value: `value for ${type}` });
-    expect(input).toHaveAttribute('value', `value for ${type}`);
-  });
+  it.each([...textLikeInputs, 'textarea'])(
+    'updates value for type "%s"',
+    type => {
+      const { change, input } = renderInput(type, 'input-name');
+      change({ value: `value for ${type}` });
+      expect(input).toHaveAttribute('value', `value for ${type}`);
+    },
+  );
 
   it.each(numericInputs)('updates value for type "%s"', type => {
     const { change, input } = renderInput(type);


### PR DESCRIPTION
Closes #11

## What

Added support for `textarea` inputs:

```jsx
import { useFormState } from 'react-use-form-state';

function Form() {
  const [formState, { textarea }] = userFormState();
  return (
    <form onSubmit={() => console.log(formState)}>
      <input {...textarea('description')} />
    </form>
  )
}
```

## Tasks

- [ ] update website
- [ ] include in release `0.4.0`