### PR TITLE
Allow useFormState to accept the state shape as a type argument

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,73 +3,73 @@
 // Definitions by: Waseem Dahman <https://github.com/wsmd>
 
 export function useFormState<
-  T extends { [key: string]: string | string[] | number }
+  T extends { [key in keyof T]: string | string[] | number | boolean }
 >(
   initialState?: T | null,
   options?: Partial<FormOptions<T>>,
 ): [FormState<T>, Inputs];
 
 interface FormState<T> {
-  values: InputValues<T>;
-  validity: InputValuesValidity<T>;
-  touched: InputValuesValidity<T>;
+  values: StateValues<T>;
+  validity: StateValidity<T>;
+  touched: StateValidity<T>;
 }
 
 interface FormOptions<T> {
   onChange(
     e: React.ChangeEvent<InputElement>,
-    stateValues: InputValues<T>,
-    nextStateValues: InputValues<T>,
+    stateValues: StateValues<T>,
+    nextStateValues: StateValues<T>,
   ): void;
   onBlur(e: React.FocusEvent<InputElement>): void;
   onTouched(e: React.FocusEvent<InputElement>): void;
 }
 
+type StateValues<T> = {
+  readonly [A in keyof T]: T[A] extends number ? string : T[A]
+} & {
+  readonly [key: string]: Maybe<string | string[] | boolean>;
+};
+
+type StateValidity<T> = { readonly [A in keyof T]: Maybe<boolean> } & {
+  readonly [key: string]: Maybe<boolean>;
+};
+
+// Inputs
+
 interface Inputs {
-  selectMultiple(name: string): Omit<InputProps, 'type'> & MultipleProp;
-  select(name: string): Omit<InputProps, 'type'>;
-  email(name: string): InputProps;
-  color(name: string): InputProps;
-  password(name: string): InputProps;
-  text(name: string): InputProps;
-  textarea(name: string): Omit<InputProps, 'type'>;
-  url(name: string): InputProps;
-  search(name: string): InputProps;
-  number(name: string): InputProps;
-  range(name: string): InputProps;
-  tel(name: string): InputProps;
-  radio(name: string, value: string): InputProps & CheckedProp;
+  selectMultiple(name: string): Omit<BaseInputProps, 'type'> & MultipleProp;
+  select(name: string): Omit<BaseInputProps, 'type'>;
+  email(name: string): BaseInputProps;
+  color(name: string): BaseInputProps;
+  password(name: string): BaseInputProps;
+  text(name: string): BaseInputProps;
+  textarea(name: string): Omit<BaseInputProps, 'type'>;
+  url(name: string): BaseInputProps;
+  search(name: string): BaseInputProps;
+  number(name: string): BaseInputProps;
+  range(name: string): BaseInputProps;
+  tel(name: string): BaseInputProps;
+  radio(name: string, value: string): RadioProps;
   /**
    * Checkbox inputs with a value will be treated as a collection of choices.
    * Their values in in the form state will be of type Array<string>
    */
-  checkbox(name: string, value: string): InputProps & CheckedProp;
+  checkbox(name: string, value: string): CheckboxProps;
   /**
    * Checkbox inputs without a value will be treated as toggles. Their values in
    * in the form state will be of type boolean
    */
-  checkbox(name: string): InputProps & CheckedProp;
-  date(name: string): InputProps;
-  month(name: string): InputProps;
-  week(name: string): InputProps;
-  time(name: string): InputProps;
+  checkbox(name: string): CheckboxProps;
+  date(name: string): BaseInputProps;
+  month(name: string): BaseInputProps;
+  week(name: string): BaseInputProps;
+  time(name: string): BaseInputProps;
 }
-
-type Maybe<T> = T | void;
-
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 type InputElement = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 
-type InputValues<T> = { readonly [A in keyof T]: T[A] } & {
-  readonly [key: string]: Maybe<string | string[]>;
-};
-
-type InputValuesValidity<T> = { readonly [A in keyof T]: Maybe<boolean> } & {
-  readonly [key: string]: Maybe<boolean>;
-};
-
-interface InputProps {
+interface BaseInputProps {
   onChange(e: any): void;
   onBlur(e: any): void;
   value: string;
@@ -77,10 +77,18 @@ interface InputProps {
   type: string;
 }
 
-interface CheckedProp {
+interface CheckboxProps extends BaseInputProps {
   checked: boolean;
 }
+
+interface RadioProps extends CheckboxProps {}
 
 interface MultipleProp {
   multiple: boolean;
 }
+
+// Utils
+
+type Maybe<T> = T | undefined;
+
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,7 +25,13 @@ interface FormOptions<T> {
   onTouched(e: React.FocusEvent<InputElement>): void;
 }
 
+// prettier-ignore
 type StateValues<T> = {
+  /**
+   * Even though we're accepting a number as a default value for numeric inputs
+   * (e.g. type=number and type=range), the value we store in  state for those
+   * inputs will will be of a string
+   */
   readonly [A in keyof T]: T[A] extends number ? string : T[A]
 } & {
   readonly [key: string]: Maybe<string | string[] | boolean>;

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -8,6 +8,8 @@ useFormState(null);
 const initialState = {
   username: 'wsmd',
   colors: ['yellow', 'red'],
+  power_level: 9000,
+  remember_me: true,
 };
 
 const [formState, input] = useFormState(initialState, {
@@ -30,11 +32,22 @@ const [formState, input] = useFormState(initialState, {
   },
 });
 
+let username: string = formState.values.username;
+
+formState.values.colors.forEach(color => console.log(color));
+
+/**
+ * Even though we're accepting a number as a default value for numeric inputs
+ * (e.g. type=number and type=range), the value we store in state will be a string
+ */
+let level: string = formState.values.power_level;
+
+/**
+ * values of validity and touched will be determined via the blur event. Until
+ * the even is fired, the values will be of type undefined
+ */
 formState.touched.colors;
 formState.validity.username;
-
-formState.values.username;
-formState.values.colors.forEach(color => console.log(color));
 
 <input {...input.checkbox('name', 'value')} />;
 <input {...input.color('name')} />;
@@ -56,3 +69,17 @@ formState.values.colors.forEach(color => console.log(color));
 <select {...input.selectMultiple('name')} />;
 
 <textarea {...input.textarea('name')} />;
+
+// typed state
+
+interface ConnectFormState {
+  user: string;
+  host: string;
+  password: string;
+  database: string;
+  port: number;
+}
+
+const [typedState] = useFormState<ConnectFormState>();
+
+const { port, host }: { port: string; host: string } = typedState.values;

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -37,10 +37,11 @@ let username: string = formState.values.username;
 formState.values.colors.forEach(color => console.log(color));
 
 /**
- * Even though we're accepting a number as a default value for numeric inputs
- * (e.g. type=number and type=range), the value we store in state will be a string
+ * numeric values will be retrieved as strings
  */
 let level: string = formState.values.power_level;
+
+let rememberMe: boolean = formState.values.remember_me;
 
 /**
  * values of validity and touched will be determined via the blur event. Until


### PR DESCRIPTION
Fixes #22 

**Example**

```ts
interface FormState {
  host: string;
  port: number;
  multiple: string[];
  remember: boolean;
}

const [state] = useFormState<FormState>();

state.values.host; // string
state.values.port; // string
state.values.multiple; // string[]
state.values.remember; // boolean

state.values.potentialValue; // string | boolean | string[] | undefined
```