### PR TITLE
Allow non-string values to be used as ownValue

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,10 @@
     "consistent-return": "off",
     "getter-return": "off",
     "arrow-parens": ["error", "as-needed"],
-    "react/jsx-filename-extension": ["error", { "extensions": [".js", ".jsx"] }]
+    "react/jsx-filename-extension": [
+      "error",
+      { "extensions": [".js", ".jsx"] }
+    ],
+    "import/prefer-default-export": false
   }
 }

--- a/README.md
+++ b/README.md
@@ -284,27 +284,27 @@ An object with keys as input types. Each type is a function that returns the app
 
 The following types are currently supported:
 
-| Type and Usage                                              | State Shape                         |
-| ----------------------------------------------------------- | ----------------------------------- |
-| `<input {...input.email(name: string) />`                   | `{ [name: string]: string }`        |
-| `<input {...input.color(name: string) />`                   | `{ [name: string]: string }`        |
-| `<input {...input.password(name: string) />`                | `{ [name: string]: string }`        |
-| `<input {...input.text(name: string) />`                    | `{ [name: string]: string }`        |
-| `<input {...input.url(name: string) />`                     | `{ [name: string]: string }`        |
-| `<input {...input.search(name: string) />`                  | `{ [name: string]: string }`        |
-| `<input {...input.number(name: string) />`                  | `{ [name: string]: string }`        |
-| `<input {...input.range(name: string) />`                   | `{ [name: string]: string }`        |
-| `<input {...input.tel(name: string) />`                     | `{ [name: string]: string }`        |
-| `<input {...input.radio(name: string, value: string) />`    | `{ [name: string]: string }`        |
-| `<input {...input.checkbox(name: string, value: string) />` | `{ [name: string]: Array<string> }` |
-| `<input {...input.checkbox(name: string) />`                | `{ [name: string]: boolean }`       |
-| `<input {...input.date(name: string) />`                    | `{ [name: string]: string }`        |
-| `<input {...input.month(name: string) />`                   | `{ [name: string]: string }`        |
-| `<input {...input.week(name: string) />`                    | `{ [name: string]: string }`        |
-| `<input {...input.time(name: string) />`                    | `{ [name: string]: string }`        |
-| `<select {...input.select(name: string) />`                 | `{ [name: string]: string }`        |
-| `<select {...input.selectMultiple(name: string) />`         | `{ [name: string]: Array<string> }` |
-| `<textarea {...input.textarea(name: string) />`             | `{ [name: string]: string }`        |
+| Type and Usage                                                 | State Shape                         |
+| -------------------------------------------------------------- | ----------------------------------- |
+| `<input {...input.email(name: string) />`                      | `{ [name: string]: string }`        |
+| `<input {...input.color(name: string) />`                      | `{ [name: string]: string }`        |
+| `<input {...input.password(name: string) />`                   | `{ [name: string]: string }`        |
+| `<input {...input.text(name: string) />`                       | `{ [name: string]: string }`        |
+| `<input {...input.url(name: string) />`                        | `{ [name: string]: string }`        |
+| `<input {...input.search(name: string) />`                     | `{ [name: string]: string }`        |
+| `<input {...input.number(name: string) />`                     | `{ [name: string]: string }`        |
+| `<input {...input.range(name: string) />`                      | `{ [name: string]: string }`        |
+| `<input {...input.tel(name: string) />`                        | `{ [name: string]: string }`        |
+| `<input {...input.radio(name: string, ownValue: string) />`    | `{ [name: string]: string }`        |
+| `<input {...input.checkbox(name: string, ownValue: string) />` | `{ [name: string]: Array<string> }` |
+| `<input {...input.checkbox(name: string) />`                   | `{ [name: string]: boolean }`       |
+| `<input {...input.date(name: string) />`                       | `{ [name: string]: string }`        |
+| `<input {...input.month(name: string) />`                      | `{ [name: string]: string }`        |
+| `<input {...input.week(name: string) />`                       | `{ [name: string]: string }`        |
+| `<input {...input.time(name: string) />`                       | `{ [name: string]: string }`        |
+| `<select {...input.select(name: string) />`                    | `{ [name: string]: string }`        |
+| `<select {...input.selectMultiple(name: string) />`            | `{ [name: string]: Array<string> }` |
+| `<textarea {...input.textarea(name: string) />`                | `{ [name: string]: string }`        |
 
 
 ## License

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,12 +56,12 @@ interface Inputs {
   number(name: string): BaseInputProps;
   range(name: string): BaseInputProps;
   tel(name: string): BaseInputProps;
-  radio(name: string, value: string): RadioProps;
+  radio(name: string, ownValue: OwnValue): RadioProps;
   /**
    * Checkbox inputs with a value will be treated as a collection of choices.
    * Their values in in the form state will be of type Array<string>
    */
-  checkbox(name: string, value: string): CheckboxProps;
+  checkbox(name: string, ownValue: OwnValue): CheckboxProps;
   /**
    * Checkbox inputs without a value will be treated as toggles. Their values in
    * in the form state will be of type boolean
@@ -74,6 +74,8 @@ interface Inputs {
 }
 
 type InputElement = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+
+type OwnValue = string | number | boolean | string[];
 
 interface BaseInputProps {
   onChange(e: any): void;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,1 @@
-/* eslint import/prefer-default-export: off */
-
 export { default as useFormState } from './useFormState';

--- a/src/stateReducer.js
+++ b/src/stateReducer.js
@@ -1,3 +1,6 @@
-export default function stateReducer(state, newState) {
+/**
+ * Shallowly merge newState into state
+ */
+export function stateReducer(state, newState) {
   return { ...state, ...newState };
 }

--- a/src/toString.js
+++ b/src/toString.js
@@ -1,0 +1,14 @@
+/**
+ * Cast non-string values to a string, with the exception of functions, symbols,
+ * and undefined.
+ */
+export function toString(value) {
+  switch (typeof value) {
+    case 'function':
+    case 'symbol':
+    case 'undefined':
+      return '';
+    default:
+      return '' + value; // eslint-disable-line prefer-template
+  }
+}

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -1,5 +1,6 @@
 import { useReducer } from 'react';
-import stateReducer from './stateReducer';
+import { stateReducer } from './stateReducer';
+import { toString } from './toString';
 import {
   TYPES,
   SELECT,
@@ -8,17 +9,6 @@ import {
   TEXTAREA,
   SELECT_MULTIPLE,
 } from './constants';
-
-function toString(value) {
-  switch (typeof value) {
-    case 'function':
-    case 'symbol':
-    case 'undefined':
-      return '';
-    default:
-      return '' + value; // eslint-disable-line prefer-template
-  }
-}
 
 function noop() {}
 

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -118,7 +118,7 @@ export default function useFormState(initialState, options) {
          * returning the value of input from the current form state is illogical
          */
         if (isCheckbox || isRadio) {
-          return ownValue;
+          return toString(ownValue);
         }
         return hasValueInState ? state[name] : '';
       },

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -9,6 +9,17 @@ import {
   SELECT_MULTIPLE,
 } from './constants';
 
+function toString(value) {
+  switch (typeof value) {
+    case 'function':
+    case 'symbol':
+    case 'undefined':
+      return '';
+    default:
+      return '' + value; // eslint-disable-line prefer-template
+  }
+}
+
 function noop() {}
 
 const defaultFromOptions = {
@@ -25,7 +36,7 @@ export default function useFormState(initialState, options) {
   const [validity, setValidityState] = useReducer(stateReducer, {});
 
   const createPropsGetter = type => (name, ownValue) => {
-    const hasOwnValue = !!ownValue;
+    const hasOwnValue = !!toString(ownValue);
     const hasValueInState = state[name] !== undefined;
     const isCheckbox = type === CHECKBOX;
     const isRadio = type === RADIO;
@@ -79,7 +90,7 @@ export default function useFormState(initialState, options) {
       },
       get checked() {
         if (isRadio) {
-          return state[name] === ownValue;
+          return state[name] === toString(ownValue);
         }
         if (isCheckbox) {
           if (!hasOwnValue) {
@@ -91,7 +102,9 @@ export default function useFormState(initialState, options) {
            * <input {...input.checkbox('option1')} />
            * <input {...input.checkbox('option1', 'value_of_option1')} />
            */
-          return hasValueInState ? state[name].includes(ownValue) : false;
+          return hasValueInState
+            ? state[name].includes(toString(ownValue))
+            : false;
         }
       },
       get value() {

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -51,13 +51,16 @@ formState.touched.colors;
 formState.validity.username;
 
 <input {...input.checkbox('name', 'value')} />;
+<input {...input.radio('name', 'value')} />;
+<input {...input.radio('name', true)} />;
+<input {...input.radio('name', 123)} />;
+<input {...input.radio('name', ['a', 'b'])} />;
 <input {...input.color('name')} />;
 <input {...input.date('name')} />;
 <input {...input.email('name')} />;
 <input {...input.month('name')} />;
 <input {...input.number('name')} />;
 <input {...input.password('name')} />;
-<input {...input.radio('name', 'value')} />;
 <input {...input.range('name')} />;
 <input {...input.search('name')} />;
 <input {...input.tel('name')} />;

--- a/test/useFormState.test.js
+++ b/test/useFormState.test.js
@@ -125,6 +125,7 @@ describe('input type methods return correct props object', () => {
       checked: false,
       onChange: expect.any(Function),
       onBlur: expect.any(Function),
+      value: '',
     });
   });
 
@@ -221,9 +222,9 @@ describe('inputs receive default values from initial state', () => {
     const initialState = { option1: true };
     const [, input] = useFormState(initialState);
     expect(input.checkbox('option1').checked).toEqual(true);
-    expect(input.checkbox('option1').value).toEqual(undefined);
+    expect(input.checkbox('option1').value).toEqual('');
     expect(input.checkbox('option2').checked).toEqual(false);
-    expect(input.checkbox('option2').value).toEqual(undefined);
+    expect(input.checkbox('option2').value).toEqual('');
   });
 
   it('sets initial "checked" for type "radio"', () => {

--- a/test/useFormState.test.js
+++ b/test/useFormState.test.js
@@ -145,6 +145,26 @@ describe('input type methods return correct props object', () => {
   });
 
   /**
+   * Stringify non-string ownValue of checkbox and radio
+   */
+  it.each`
+    type          | ownValue      | expected
+    ${'array'}    | ${[1, 2]}     | ${'1,2'}
+    ${'boolean'}  | ${false}      | ${'false'}
+    ${'number'}   | ${1}          | ${'1'}
+    ${'object'}   | ${{}}         | ${'[object Object]'}
+    ${'function'} | ${() => {}}   | ${''}
+    ${'Symbol'}   | ${Symbol('')} | ${''}
+  `(
+    'stringify ownValue of type $type for checkbox and radio',
+    ({ ownValue, expected }) => {
+      const [, input] = useFormState();
+      expect(input.checkbox('option1', ownValue).value).toEqual(expected);
+      expect(input.radio('option2', ownValue).value).toEqual(expected);
+    },
+  );
+
+  /**
    * Select doesn't need a type
    */
   it('returns props for type "select"', () => {


### PR DESCRIPTION
Fixes #14 

```ts
<input {...input.checkbox('options', 'value')} />;
<input {...input.checkbox('options', true)} />;
<input {...input.checkbox('options', 123)} />;
<input {...input.checkbox('options', ['a', 'b'])} />;

{
  "values": {
    "options": [
      "value",
      "123",
      "a,b",
      "true"
    ]
  }
}
```

```ts
<input {...input.radio('option', '1')} />;
<input {...input.radio('option', 1)} />;
<input {...input.radio('option', ['1'])} />;

{
  "values": {
    "option": "1"
  }
}
```