### PR TITLE
Add event as validate argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ export default function SignUpForm() {
           onChange: e => console.log('password input changed!'),
           onBlur: e => console.log('password input lost focus!'),
           validateOnBlur: true,
-          validate: (value, values) =>
+          validate: (value, values, event) =>
+            event.target.validity.valid &&
             !value.includes(values.username) &&
             STRONG_PASSWORD_REGEX.test(value),
         })}
@@ -449,7 +450,7 @@ The following options can be passed:
 | `value: string`                                         | The input's own value. Only required by the `radio` input, and optional for the `checkbox` input.                                                                                                                                                               |
 | `onChange(e): void`                                     | Optional. A change event handler that gets passed the input's `change` [`SyntheticEvent`](https://reactjs.org/docs/events.html).                                                                                                                                |
 | `onBlur(e): void`                                       | Optional. A blur event handler that gets passed the input's `blur` [`SyntheticEvent`](https://reactjs.org/docs/events.html).                                                                                                                                    |
-| `validate(value: string, values: StateValues): boolean` | Optional. An input validation function that gets passed the input value and all input values in the state. It's expected to return a boolean indicating whether the input's value is valid. HTML5 validation rules are ignored when this function is specified. |
+| `validate(value: string, values: StateValues, event: Event): boolean` | Optional. An input validation function that gets passed the input value, all input values in the state, and the change event. It's expected to return a boolean indicating whether the input's value is valid. HTML5 validation rules are ignored when this function is specified. |
 | `validateOnBlur: boolean`                               | Optional. `false` by default. When set to `true` and the `validate` function is provided, the function will be called when the input loses focus. If not specified, the `validate` function will be called on value change.                                     |
 
 ## License

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -81,7 +81,7 @@ export default function useFormState(initialState, options) {
 
     function getValidationResult(e, values = state) {
       if (typeof inputOptions.validate === 'function') {
-        return !!inputOptions.validate(e.target.value, values);
+        return !!inputOptions.validate(e.target.value, values, e);
       }
       return e.target.validity.valid;
     }

--- a/test/useFormState.test.js
+++ b/test/useFormState.test.js
@@ -306,7 +306,7 @@ describe('passing an object to input type method with callbacks', () => {
     fire('blur');
     expect(validate).toHaveBeenCalledWith('shall not pass', {
       name: 'shall not pass',
-    });
+    }, expect.any(Object));
     expect(stateChangeHandler).toHaveBeenLastCalledWith(
       expect.objectContaining({ validity: { name: false } }),
     );
@@ -315,7 +315,7 @@ describe('passing an object to input type method with callbacks', () => {
     fire('blur');
     expect(validate).toHaveBeenCalledWith('shall pass', {
       name: 'shall pass',
-    });
+    }, expect.any(Object));
     expect(stateChangeHandler).toHaveBeenLastCalledWith(
       expect.objectContaining({ validity: { name: true } }),
     );


### PR DESCRIPTION
Adds change `event` to `validate` as a third parameter, so you can use `HTML5` validations in your `validate` function

```jsx
<input
  {...password({
    name: 'password',
    validate: (value, values, event) =>
      event.target.validity.valid &&
      !value.includes(values.username) &&
      STRONG_PASSWORD_REGEX.test(value),
  })}
/>
```

With this you can get more descriptive errors, as this quickly put together example shows:
```jsx
const [passwordError, updatePasswordError] = useState(null);

return (
  <input
    required
    pattern={STRONG_PASSWORD_REGEX}
    minLength="6"
    {...password({
      name: 'password',
      validate: (value, values, event) => {
        if (event.target.validity.valueMissing) {
          updatePasswordError('Password is required');
          return false;
        } else if (event.target.validity.tooShort) {
          updatePasswordError(`Password needs to be at least ${event.target.maxlength} characters long`);
          return false;
        } else if (!value.includes(values.username)) {
          updatePasswordError('Password should not contain your username');
          return false;
        } else if (event.target.patternMismatch) {
          updatePasswordError('Password is not strong enough');
          return false;
        }
        updatePasswordError(null);
        return true;
      }
    })}
  />
)
```