### PR TITLE
Add support for inputs with custom onChange

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -46,3 +46,5 @@ export const TYPES = [
 
 export const ON_CHANGE_HANDLER = 0;
 export const ON_BLUR_HANDLER = 1;
+
+export const CONSOLE_TAG = '[react-use-form-state]';

--- a/src/parseInputArgs.js
+++ b/src/parseInputArgs.js
@@ -5,6 +5,7 @@ const defaultInputOptions = {
   onBlur: noop,
   validate: null,
   validateOnBlur: false,
+  touchedOnChange: false,
 };
 
 export function parseInputArgs(args) {

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { toString, noop, omit, isFunction, isEmpty, isString } from './utils';
 import { parseInputArgs } from './parseInputArgs';
 import { useInputId } from './useInputId';
@@ -46,9 +45,6 @@ export default function useFormState(initialState, options) {
     const key = `${type}.${name}.${toString(ownValue)}`;
 
     function setInitialValue() {
-      /**
-       * @type {string | string[] |boolean}
-       */
       let value = '';
       if (isCheckbox) {
         /**
@@ -85,10 +81,6 @@ export default function useFormState(initialState, options) {
       );
     }
 
-    /**
-     * @param {React.ChangeEvent<HTMLInputElement> | string} e event or value
-     * @param {string[]} values
-     */
     function validate(e, values = formState.current.values) {
       let error;
       let isValid = true;
@@ -126,6 +118,13 @@ export default function useFormState(initialState, options) {
       }
       formState.setValidity({ [name]: isValid });
       formState.setError(isEmpty(error) ? omit(name) : { [name]: error });
+    }
+
+    function touch(e) {
+      if (!formState.current.touched[name]) {
+        formState.setTouched({ [name]: true });
+        formOptions.onTouched(e);
+      }
     }
 
     const inputProps = {
@@ -198,15 +197,14 @@ export default function useFormState(initialState, options) {
         if (!inputOptions.validateOnBlur) {
           validate(e, newValues);
         }
+        if (inputOptions.touchedOnChange) {
+          touch(e);
+        }
 
         formState.setValues(partialNewState);
       }),
       onBlur: callbacks.getOrSet(ON_CHANGE_HANDLER + key, e => {
-        if (!formState.current.touched[name]) {
-          formState.setTouched({ [name]: true });
-          formOptions.onTouched(e);
-        }
-
+        touch(e);
         inputOptions.onBlur(e);
         formOptions.onBlur(e);
 

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -90,8 +90,8 @@ export default function useFormState(initialState, options) {
       const customValidate =
         isFunction(inputOptions.validate) && inputOptions.validate;
 
-      if (isString(e) && !customValidate) {
-        if (process.env.NODE_ENV === 'development') {
+      if (process.env.NODE_ENV === 'development') {
+        if (isString(e) && !customValidate) {
           if (!missingValidateWarnings.has(key)) {
             // eslint-disable-next-line no-console
             console.warn(

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,6 +33,14 @@ export function isFunction(value) {
   return typeof value === 'function';
 }
 
+/**
+ * @param {any} value
+ * @return {value is string}
+ */
+export function isString(value) {
+  return typeof value === 'string';
+}
+
 const objectToString = value => Object.prototype.toString.call(value);
 
 /**


### PR DESCRIPTION
Closes #43
Closes #21 (related)
Closes #54

---

### Description

This PR adds support for custom inputs or 3rd party controls that have a custom `onChange` method (for example, their `onChange` prop is called with a value other than the SyntheticEvent).

This PR leverages the existing `onChange` callback that is passed as an input option.

```js
<Custom3rdPartyLibInput
  {...input({
    name: 'username',
    // onChange is called with a custom object the we can map to a value.
    // this could also be an identity function if the onChange is called with a string
    onChange: result => result.value,
  })
/>
```

This problems was addressed in #54. However, this approach have some advantages over #54:

- Leverages existing APIs = no new APIs introduced = less overhead
- Very little logic involved
- #54 assumes that the `onChange` of `.raw` will always be called with the exact input value. This still has some limitations as some custom inputs may call `onChange` with all different kind of objects and not necessarily the value itself (as shown in the example above).
- On the other hand, this approach allows the developer to determine the exact value to be stored in the form state by taking the argument of the input's `onChange` callback and returning the exact input value back.
- Added `touchedOnChange` to get round the possibility of custom inputs not supporting `onBlur` – this can also be considered a bonus feature as it can be a desired behavior with native inputs as well.
- Enhanced developer experience by guiding the developer to better integrate `react-use-form-state` with custom inputs when it comes to validating such inputs:

<img width="488" alt="Screen Shot 2019-04-17 at 12 39 07 AM" src="https://user-images.githubusercontent.com/2100222/56261507-3ebfaf80-60a9-11e9-86a1-3dd518297215.png">

### Todo

- [ ] write tests
- [ ] update docs
- [ ] update types