### PR TITLE
Improve type safety of StateValues/StateValidity keys

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,13 +44,9 @@ type StateValues<T> = {
    * inputs will will be of a string
    */
   readonly [A in keyof T]: T[A] extends number ? string : T[A]
-} & {
-  readonly [key: string]: Maybe<string | string[] | boolean>;
 };
 
-type StateValidity<T> = { readonly [A in keyof T]: Maybe<boolean> } & {
-  readonly [key: string]: Maybe<boolean>;
-};
+type StateValidity<T> = { readonly [A in keyof T]: Maybe<boolean> };
 
 type StateErrors<T, E = string> = { readonly [A in keyof T]?: E | string };
 

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -53,11 +53,11 @@ let rememberMe: boolean = formState.values.remember_me;
  * the even is fired, the values will be of type undefined
  */
 formState.touched.colors;
-formState.validity.username;
-
+formState.validity.name;
+formState.values.power_level.split('');
 if (formState.errors.colors) {
   // string
-  formState.errors.colors;
+  formState.errors.colors.toLocaleLowerCase();
 }
 
 <input {...input.checkbox('remember_me')} />;


### PR DESCRIPTION
Closes #60 

Improves type safety on keys that do not exist in the form state:

```ts
interface FormFields {
  name: string;
}

[formState, inputs] = useFormState();

formState.values.fieldThatDoesNotExists // no errors (but it should throw)
```