### PR TITLE
Fix `validate` default arg and erroneous invocation in `onBlur`

### DIFF
--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -28,10 +28,11 @@ export default function useFormState(initialState, options) {
 
   const formState = useState({ initialState, ...formOptions });
   const { getIdProp } = useInputId(formOptions.withIds);
-  const { set: setDirty, has: isDirty } = useCache();
+  const { set: setDirty } = useCache();
   const devWarnings = useCache();
 
   function warn(key, type, message) {
+    /* istanbul ignore else */
     if (!devWarnings.has(`${type}:${key}`)) {
       devWarnings.set(`${type}:${key}`, true);
       // eslint-disable-next-line no-console
@@ -109,7 +110,7 @@ export default function useFormState(initialState, options) {
 
     function validate(
       e,
-      value = isRaw ? undefined : e.target.value,
+      value = isRaw ? e : e.target.value,
       values = formState.current.values,
     ) {
       let error;
@@ -256,16 +257,7 @@ export default function useFormState(initialState, options) {
         inputOptions.onBlur(e);
         formOptions.onBlur(e);
 
-        /**
-         * Limiting input validation on blur to:
-         * A) when it's either touched for the first time
-         * B) when it's marked as dirty due to a value change
-         */
-        /* istanbul ignore else */
-        if (!formState.current.touched[name] || isDirty(name)) {
-          validate(e);
-          setDirty(name, false);
-        }
+        if (inputOptions.validateOnBlur) validate(e);
       },
       ...getIdProp('id', name, ownValue),
     };

--- a/test/useFormState-input.test.js
+++ b/test/useFormState-input.test.js
@@ -481,7 +481,7 @@ describe('Input blur behavior', () => {
     expect(formState.current).toEqual(
       expect.objectContaining({
         values: { name: '' },
-        validity: { name: true },
+        validity: {},
         errors: {},
         touched: { name: true },
       }),
@@ -517,9 +517,9 @@ describe('Input blur behavior', () => {
     expect(formState.current.touched.value).toEqual(true);
   });
 
-  it('marks input as invalid on blur', () => {
+  it('validates on blur when validateOnBlur=true', () => {
     const { blur, formState } = renderWithFormState(([, { text }]) => (
-      <input {...text('name')} required />
+      <input {...text({ name: 'name', validateOnBlur: true })} required />
     ));
     blur();
     expect(formState.current).toEqual(
@@ -529,6 +529,54 @@ describe('Input blur behavior', () => {
         errors: {
           name: expect.any(String),
         },
+        touched: { name: true },
+      }),
+    );
+  });
+
+  it('does not validate on blur when validateOnBlur!=true', () => {
+    const { blur, formState } = renderWithFormState(([, { text }]) => (
+      <input {...text({ name: 'name' })} required />
+    ));
+    blur();
+    expect(formState.current).toEqual(
+      expect.objectContaining({
+        values: { name: '' },
+        validity: {},
+        errors: {},
+        touched: { name: true },
+      }),
+    );
+  });
+
+  it('raw validates on blur when validateOnBlur=true', () => {
+    const { blur, formState } = renderWithFormState(([, { raw }]) => (
+      <input
+        {...raw({ name: 'name', validateOnBlur: true, validate: () => 'fail' })}
+        required
+      />
+    ));
+    blur();
+    expect(formState.current).toEqual(
+      expect.objectContaining({
+        values: { name: '' },
+        validity: { name: false },
+        errors: { name: 'fail' },
+        touched: { name: true },
+      }),
+    );
+  });
+
+  it('raw does not validate on blur when validateOnBlur!=true', () => {
+    const { blur, formState } = renderWithFormState(([, { raw }]) => (
+      <input {...raw({ name: 'name' })} required />
+    ));
+    blur();
+    expect(formState.current).toEqual(
+      expect.objectContaining({
+        values: { name: '' },
+        validity: {},
+        errors: {},
         touched: { name: true },
       }),
     );


### PR DESCRIPTION
fixes #73 

`validate`'s second argument was assigned `undefined` by default
when `isRaw`, which caused `inputOptions.validate` to be
invoked with undefined. The default was changed to be the same
value as `validate`'s first argument.

`inputProps.onBlur` was erroneously invoking `validate` when
`inputOption.validateOnBlur` is `false`.
`inputOptions.validateOnBlur` is now checked before invoking
`validate`

These fixes surfaces a couple erroneous unit tests, which were
corrected as well.