### PR TITLE
Fix stale closures of callback options in inputs.text et. al.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -46,7 +46,4 @@ export const TYPES = [
   WEEK,
 ];
 
-export const ON_CHANGE_HANDLER = 0;
-export const ON_BLUR_HANDLER = 1;
-
 export const CONSOLE_TAG = '[useFormState]';

--- a/src/useCache.js
+++ b/src/useCache.js
@@ -5,8 +5,6 @@ export function useCache() {
   const has = key => cache.current.has(key);
   const get = key => cache.current.get(key);
   const set = (key, value) => cache.current.set(key, value);
-  const getOrSet = (key, value) =>
-    has(key) ? get(key) : set(key, value) && get(key);
 
-  return { getOrSet, set, has, get };
+  return { set, has, get };
 }

--- a/src/useCache.js
+++ b/src/useCache.js
@@ -5,6 +5,8 @@ export function useCache() {
   const has = key => cache.current.has(key);
   const get = key => cache.current.get(key);
   const set = (key, value) => cache.current.set(key, value);
+  const getOrSet = (key, value) =>
+    has(key) ? get(key) : set(key, value) && get(key);
 
-  return { set, has, get };
+  return { getOrSet, set, has, get };
 }

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -12,8 +12,6 @@ import {
   TEXTAREA,
   SELECT_MULTIPLE,
   LABEL,
-  ON_CHANGE_HANDLER,
-  ON_BLUR_HANDLER,
   CONSOLE_TAG,
 } from './constants';
 
@@ -31,7 +29,6 @@ export default function useFormState(initialState, options) {
   const formState = useState({ initialState, ...formOptions });
   const { getIdProp } = useInputId(formOptions.withIds);
   const { set: setDirty, has: isDirty } = useCache();
-  const callbacks = useCache();
   const devWarnings = useCache();
 
   function warn(key, type, message) {
@@ -202,7 +199,7 @@ export default function useFormState(initialState, options) {
 
         return hasValueInState ? formState.current.values[name] : '';
       },
-      onChange: callbacks.getOrSet(ON_BLUR_HANDLER + key, e => {
+      onChange: e => {
         setDirty(name, true);
         let value;
         if (isRaw) {
@@ -252,8 +249,8 @@ export default function useFormState(initialState, options) {
         }
 
         formState.setValues(partialNewState);
-      }),
-      onBlur: callbacks.getOrSet(ON_CHANGE_HANDLER + key, e => {
+      },
+      onBlur: e => {
         touch(e);
 
         inputOptions.onBlur(e);
@@ -269,7 +266,7 @@ export default function useFormState(initialState, options) {
           validate(e);
           setDirty(name, false);
         }
-      }),
+      },
       ...getIdProp('id', name, ownValue),
     };
 

--- a/test/useFormState-input.test.js
+++ b/test/useFormState-input.test.js
@@ -534,23 +534,3 @@ describe('Input blur behavior', () => {
     );
   });
 });
-
-describe('Input props are memoized', () => {
-  it('does not cause re-render of memoized components', () => {
-    const renderCheck = jest.fn(() => true);
-    const MemoInput = React.memo(
-      props => renderCheck() && <input {...props} />,
-    );
-    const { change, root } = renderWithFormState(([, { text }]) => (
-      <div>
-        <input {...text('foo')} />
-        <MemoInput {...text('bar')} />
-      </div>
-    ));
-    change({ value: 'a' }, root.childNodes[0]);
-    change({ value: 'b' }, root.childNodes[0]);
-    expect(renderCheck).toHaveBeenCalledTimes(1);
-    change({ value: 'c' }, root.childNodes[1]);
-    expect(renderCheck).toHaveBeenCalledTimes(2);
-  });
-});


### PR DESCRIPTION
fixes #75 

The implementation of useFormState is problematic because it
caches callback functions passed to `inputs.text` et. al. This
causes functions like `onChange`, `validate`, and `onBlur` to run with
stale closures, namely, the closure with which they are
initialised.

This commit fixes the issue by removing the `callback` cache from
the implementation. Tests that depended on this buggy behavior
were removed as they are unsupportable features given the current
implementation.