### PR TITLE
fix: Fix validation of raw values onBlur.

### DIFF
--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -112,7 +112,7 @@ export default function useFormState(initialState, options) {
 
     function validate(
       e,
-      value = isRaw ? undefined : e.target.value,
+      value = isRaw ? formState.current.values[name] : e.target.value,
       values = formState.current.values,
     ) {
       let error;

--- a/test/useFormState-validation.test.js
+++ b/test/useFormState-validation.test.js
@@ -109,6 +109,27 @@ describe('passing a custom input validate function', () => {
     expect(formState.current.errors).not.toHaveProperty('name');
   });
 
+  it('handles validation of raw values on blur', () => {
+    const validate = jest.fn(val => ((val && val.foo === 'pass') ? true : 'wrong!'));
+    let onChange;
+    let onBlur;
+    const { formState } = renderWithFormState(([, { raw }]) => {
+      const inputProps = raw({ name: 'name', validate });
+      ({ onChange, onBlur } = inputProps);
+      return <input {...inputProps} />;
+    });
+
+    onChange({ foo: 'fail' });
+    onBlur();
+    expect(formState.current.validity).toHaveProperty('name', false);
+    expect(formState.current.errors).toHaveProperty('name', 'wrong!');
+
+    onChange({ foo: 'pass' });
+    onBlur();
+    expect(formState.current.validity).toHaveProperty('name', true);
+    expect(formState.current.errors).not.toHaveProperty('name');
+  });
+
   it.each([
     ['empty array', []],
     ['empty object', {}],


### PR DESCRIPTION
Closes #73
Closes #74

When `validate()` is provided as an option to a raw() parameter, it is always called with `undefined` as the value when a blur event is fired.  This fixes it so it uses the current form state value instead.