### PR TITLE
Add setFieldError method

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ function Form() {
 Please note that when `formState.setField` is called, any existing errors that might have been set due to previous interactions from the user will be cleared, and both of the `validity` and the `touched` states of the input will be set to `true`.
 
 It's also possible to clear a single input's value using `formState.clearField`.
+It's also possible to set the error value for a single input using `formState.setFieldError` and to clear a single input's value using `formState.clearField`.
 
 ### Resetting The From State
 
@@ -599,7 +600,10 @@ formState = {
   clearField(name: string): void,
 
   // updates the value of an input
-  setField(name: string, value: string): void,,
+  setField(name: string, value: string): void,
+
+  // sets the error of an input
+  setFieldError(name: string, error: string): void,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,6 @@ function Form() {
 
 Please note that when `formState.setField` is called, any existing errors that might have been set due to previous interactions from the user will be cleared, and both of the `validity` and the `touched` states of the input will be set to `true`.
 
-It's also possible to clear a single input's value using `formState.clearField`.
 It's also possible to set the error value for a single input using `formState.setFieldError` and to clear a single input's value using `formState.clearField`.
 
 ### Resetting The From State

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,6 +25,7 @@ interface FormState<T, E = StateErrors<T, string>> {
   errors: E;
   clear(): void;
   setField<K extends keyof T>(name: K, value: T[K]): void;
+  setFieldError(name: keyof T, error: string): void;
   clearField(name: keyof T): void;
 }
 

--- a/src/useState.js
+++ b/src/useState.js
@@ -43,6 +43,10 @@ export function useState({ initialState, onClear }) {
       setField(name, value) {
         setField(name, value, true, true);
       },
+      setFieldError(name, error) {
+        setValidity({ [name]: false });
+        setError({ [name]: error });
+      },
     },
   };
 }

--- a/test/useFormState-manual-updates.test.js
+++ b/test/useFormState-manual-updates.test.js
@@ -55,4 +55,14 @@ describe('useFormState manual updates', () => {
     formState.current.setField('name', 'waseem');
     expect(formState.current.values.name).toBe('waseem');
   });
+
+  it('sets the error of an input and invalidates the input programmatically using from.setFieldError', () => {
+    const { formState } = renderWithFormState(([, input]) => (
+      <input {...input.text('name')} />
+    ));
+
+    formState.current.setFieldError('name', 'incorrect name');
+    expect(formState.current.validity.name).toBe(false);
+    expect(formState.current.errors.name).toBe('incorrect name');
+  });
 });

--- a/test/useFormState.test.js
+++ b/test/useFormState.test.js
@@ -12,6 +12,7 @@ describe('useFormState API', () => {
         errors: {},
         clear: expect.any(Function),
         setField: expect.any(Function),
+        setFieldError: expect.any(Function),
         clearField: expect.any(Function),
       },
       expect.any(Object),


### PR DESCRIPTION
Alike the `setField` method, this method sets the error of an input programmatically, without user interaction.
This is useful in cases where form validation is done server side for the complete form.

Example:
```jsx
const Form = () => {
  const api = useApi()
  const [formState, { text }] = useFormState()

  const handleSubmit = async event => {
    event.preventDefault()

    try {
      await api.submitForm(formState.values)
      // Do something else
    } catch (error) {
      formState.setFieldError('name', error.message)
    }
  }

  return (
    <form onSubmit={handleSubmit}>
      <input {...text('name')} />
      <button type="submit">Submit</button>
    </form>
  )
}
```