### PR TITLE
Added `formState.setFields` method to be able to update multiple fields at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,65 @@ Please note that when `formState.setField` is called, any existing errors that m
 
 It's also possible to set the error value for a single input using `formState.setFieldError` and to clear a single input's value using `formState.clearField`.
 
+### Updating multiple fields at once
+
+Updating the value of multiple fields in the form at once is possible via the `formState.setFields` method.
+
+This could come in handy if you're, for example, loading data from the server.
+
+```js
+function Form() {
+  const [formState, { text, email }] = useFormState();
+
+  React.useEffect(function loadDataFromServer() {
+    // we'll simulate some delay with a setTimeout. This could be your fetch() request:
+    const timer = setTimeout(() => {
+      formState.setFields({
+        name: "John",
+        age: 24,
+        email: "john@example.com" 
+      });
+    },  1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <>
+      <input {...text('name')} readOnly />
+      <input {...text('age')} readOnly />
+      <input {...email('email')} readOnly />
+    </>
+  )
+}
+
+```
+
+`formState.setFields` has a second `options` argument which can be used to update the `touched`, `validity` and `errors` in the state.
+
+`touched` and `validity` can be a boolean value which applies that value to all fields for which a value is provided.
+
+```js
+// mark all fields as valid (clears all errors):
+formState.setFields(newValues, {
+  validity: true
+});
+
+// marks only "name" as invalid:
+formState.setFields(newValues, {
+  validity: {
+    name: false
+  },
+  errors: {
+    name: "Your name is required!"
+  }
+});
+
+// marks all fields as not touched:
+formState.setFields(newValues, {
+  touched: false
+});
+```
+
 ### Resetting The From State
 
 All fields in the form can be cleared all at once at any time using `formState.clear`.
@@ -600,6 +659,9 @@ formState = {
 
   // updates the value of an input
   setField(name: string, value: string): void,
+
+  // updates multiple field values and (optionally) sets touched, validity and errors:
+  setFields(values: object, [options]: object): void,
 
   // sets the error of an input
   setFieldError(name: string, error: string): void,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,12 @@ interface UseFormStateHook {
 
 export const useFormState: UseFormStateHook;
 
+type SetFieldsOptions = {
+  touched?: StateValidity<boolean>;
+  validity?: StateValidity<boolean>;
+  errors?: StateErrors<string, string>;
+};
+
 interface FormState<T, E = StateErrors<T, string>> {
   values: StateValues<T>;
   validity: StateValidity<T>;
@@ -25,6 +31,7 @@ interface FormState<T, E = StateErrors<T, string>> {
   errors: E;
   clear(): void;
   setField<K extends keyof T>(name: K, value: T[K]): void;
+  setFields(fieldValues: StateValues<T>, options?: SetFieldsOptions): void;
   setFieldError(name: keyof T, error: string): void;
   clearField(name: keyof T): void;
 }

--- a/test/useFormState-manual-updates.test.js
+++ b/test/useFormState-manual-updates.test.js
@@ -56,6 +56,173 @@ describe('useFormState manual updates', () => {
     expect(formState.current.values.name).toBe('waseem');
   });
 
+  it('sets the values of multiple inputs using formState.setFields', () => {
+    const { formState } = renderWithFormState(([, input]) => (
+      <>
+        <input {...input.text('firstName')} />
+        <input {...input.text('lastName')} required />
+        <input {...input.number('age')} />
+      </>
+    ));
+
+    const values1 = {
+      firstName: "John",
+      lastName: "Doe",
+      age: 33
+    };
+
+    formState.current.setFields(values1);
+
+    expect(formState.current.values).toMatchObject(values1);
+    expect(Object.values(formState.current.validity)).toMatchObject([true, true, true]);
+    expect(Object.values(formState.current.touched)).toMatchObject([false, false, false]);
+    expect(Object.values(formState.current.errors)).toMatchObject([undefined, undefined, undefined]);
+
+    const values2 = {
+      firstName: "Barry",
+      lastName: ""
+    };
+
+    formState.current.setFields(values2);
+
+    const expected2 = Object.assign({}, values1, values2);
+    expect(formState.current.values).toMatchObject(expected2);
+  });
+
+  it('sets validity when provided in options of formState.setFields', () => {
+    const { formState } = renderWithFormState(([, input]) => (
+      <>
+        <input {...input.text('firstName')} />
+        <input {...input.text('lastName')} required />
+      </>
+    ));
+
+    const values = {
+      firstName: "John",
+      lastName: "Doe"
+    };
+
+    formState.current.setFields(values, {
+      validity: true
+    });
+    expect(formState.current.values).toMatchObject(values);
+    expect(formState.current.validity).toMatchObject({
+      firstName: true,
+      lastName: true
+    });
+
+    formState.current.setFields({firstName: "test", lastName: "foo"}, {
+      validity: false
+    });
+    expect(formState.current.validity).toMatchObject({
+      firstName: false,
+      lastName: false
+    });
+
+    formState.current.setFields(values, {
+      validity: {
+        firstName: true,
+        lastName: false
+      }
+    });
+    expect(Object.values(formState.current.validity)).toMatchObject([true, false]);
+  });
+
+  it('sets touched when provided in options of formState.setFields', () => {
+    const { formState } = renderWithFormState(([, input]) => (
+      <>
+        <input {...input.text('firstName')} />
+        <input {...input.text('lastName')} required />
+      </>
+    ));
+
+    const values = {
+      firstName: "John",
+      lastName: "Doe"
+    };
+
+    formState.current.setFields(values, {
+      touched: true
+    });
+    expect(formState.current.values).toMatchObject(values);
+    expect(formState.current.touched).toMatchObject({
+      firstName: true,
+      lastName: true
+    });
+
+    formState.current.setFields(values, {
+      touched: false
+    });
+    expect(formState.current.touched).toMatchObject({
+      firstName: false,
+      lastName: false
+    });
+
+    formState.current.setFields(values, {
+      touched: {
+        firstName: true,
+        lastName: false
+      }
+    });
+    expect(formState.current.touched).toMatchObject({
+      firstName: true,
+      lastName: false
+    });
+  });
+
+  it('sets the errors of the specified fields when provided in options of formState.setFields', () => {
+    const { formState } = renderWithFormState(([, input]) => (
+      <>
+        <input {...input.text('firstName')} />
+        <input {...input.text('lastName')} required />
+      </>
+    ));
+
+    const values = {
+      firstName: "John",
+      lastName: ""
+    };
+    const errors = {
+      lastName: "This field cannot be empty"
+    };
+
+    formState.current.setFields(values, {errors});
+
+    expect(formState.current.errors).toMatchObject(errors);
+    expect(formState.current.validity).toMatchObject({
+      lastName: false
+    });
+  });
+
+  it ('automatically clears errors when marking fields as valid via formState.setFields', () => {
+    const { formState } = renderWithFormState(([, input]) => (
+      <>
+        <input {...input.text('firstName')} />
+      </>
+    ));
+
+    const values = {
+      firstName: "#$%^&"
+    };
+    const errors = {
+      firstName: "That's not a name"
+    };
+    formState.current.setFields(values, {errors});
+    expect(formState.current.values).toMatchObject(values);
+    expect(formState.current.errors).toMatchObject(errors);
+
+    const newValues = {
+      firstName: "John"
+    };
+    const newValidity = {
+      firstName: true
+    };
+    formState.current.setFields(newValues, {validity: newValidity});
+
+    expect(formState.current.values).toMatchObject(newValues);
+    expect(formState.current.errors).toMatchObject({firstName: undefined});
+  });
+
   it('sets the error of an input and invalidates the input programmatically using from.setFieldError', () => {
     const { formState } = renderWithFormState(([, input]) => (
       <input {...input.text('name')} />


### PR DESCRIPTION
First of all, thank you very much for this great package! It's an absolute breeze to work with!

One thing I've been missing is the ability to set the values of multiple fields at once. One example for this is when the data is loaded from the server. Currently one must set each field individually in a loop and then all those fields are also marked as `touched` which is not the case then.

So there was a need to be able to set the values of fields in the state but also manage their `touched` and `validity` state and while we're at it we could also set `errors`.

Just setting values is simple:
```js
const values = { name: "john" };
formState.setFields(values);
```
But to be able to change the `touched` or `validity` state or set `errors` a second `options` argument can be provided:
```js
const values = { name: "" };
formState.setFields(values, {
  // mark all fields as not touched:
  touched: false
  // mark specific fields as invalid:
  validity: {
    name: false
  },
  // set errors:
  errors: {
    name: "this field is required"
  }
});
```

Actually setting the `validity` of a field to `false` when also providing an error for it is redundant so I took the liberty of marking fields for which errors are provided as invalid **if and only if** no `validity` option is passed.

The same goes for setting the `validity` of a field to `true`. If a field is valid then you probably don't want to show an error so those are cleared **if and only if** no errors option is passed.

I did my best to make this PR as complete as possible:
- Added multiple tests
- Updated the `index.d.ts` file. (Please check it because I'm no TypeScript expert!)
- Updated the `README.md`.

Hope you appreciate it!

Kind regards,
Johan