### PR TITLE
Add pristine functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ const isPristine = isEmpty(formState.pristine);
 
 Checking if field is pristine is done with simple equality `===`, with some exceptions: Field is considered pristine if initial value is null or undefined and later value is empty string.
 
-This can be overriden per field by providing pristinify function:
+This can be overriden per field by providing compare function:
 
 Value will always pristine:
 
@@ -278,7 +278,7 @@ Value will always pristine:
 <input
   {...text({
     name: 'name',
-    pristinify: () => true,
+    compare: () => true,
   })}
 />
 ```
@@ -289,7 +289,7 @@ Use other equals function:
 <input
   {...raw({
     name: 'userObj',
-    pristinify: (initialValue, value) => isEqualDeep(initialValue, value),
+    compare: (initialValue, value) => isEqualDeep(initialValue, value),
   })}
 />
 ```

--- a/README.md
+++ b/README.md
@@ -257,6 +257,43 @@ If the input's value is invalid based on the rules specified above, the form sta
 
 If the `validate()` method is not specified, `useFormState` will fallback to the HTML5 constrains validation to determine the validity of the input along with the appropriate error message.
 
+### Pristine - if values have been changed
+
+`useFormState` also returns object `pristine` with fields that are not pristine. Eg: if user edits input field and changes it back manually: 'car'=>'car2'=>'car'
+
+And this can be used for Save button, to disable it, if there are no actual changes:
+
+```
+const isPristine = isEmpty(formState.pristine);
+<Button disabled={isPristine} onClick={handleClick}>Save</Button>
+```
+
+Checking if field is pristine is done with simple equality `===`, with some exceptions: Field is considered pristine if initial value is null or undefined and later value is empty string.
+
+This can be overriden per field by providing pristinify function:
+
+Value will always pristine:
+
+```jsx
+<input
+  {...text({
+    name: 'name',
+    pristinify: () => true,
+  })}
+/>
+```
+
+Use other equals function:
+
+```jsx
+<input
+  {...raw({
+    name: 'userObj',
+    pristinify: (initialValue, value) => isEqualDeep(initialValue, value),
+  })}
+/>
+```
+
 ### Without Using a `<form />` Element
 
 `useFormState` is not limited to actual forms. It can be used anywhere inputs are used.

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "rollup": "^0.66.6",
     "rollup-plugin-babel": "^4.0.3",
     "typescript": "^3.3.3333"
+  },
+  "dependencies": {
+    "lodash": "^4.17.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,8 +80,5 @@
     "rollup": "^0.66.6",
     "rollup-plugin-babel": "^4.0.3",
     "typescript": "^3.3.3333"
-  },
-  "dependencies": {
-    "lodash": "^4.17.15"
   }
 }

--- a/src/parseInputArgs.js
+++ b/src/parseInputArgs.js
@@ -1,4 +1,4 @@
-import { identity, noop } from './utils';
+import { identity, noop, isEqualByValue } from './utils';
 
 const defaultInputOptions = {
   onChange: identity,
@@ -6,6 +6,7 @@ const defaultInputOptions = {
   validate: null,
   validateOnBlur: undefined,
   touchOnChange: false,
+  compare: isEqualByValue,
 };
 
 export function parseInputArgs(args) {

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -254,15 +254,10 @@ export default function useFormState(initialState, options) {
           touch(e);
         }
 
-        let isPristine;
-        if (isFunction(inputOptions.compare)) {
-          isPristine = inputOptions.compare(
-            formState.initialValues.get(name),
-            value,
-          );
-        } else {
-          isPristine = isEqualByValue(formState.initialValues.get(name), value);
-        }
+        const isPristine = inputOptions.compare(
+          formState.initialValues.get(name),
+          value,
+        );
 
         formState.setPristine(isPristine ? omit(name) : { [name]: false });
 

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -1,4 +1,11 @@
-import { toString, noop, omit, isFunction, isEmpty } from './utils';
+import {
+  toString,
+  noop,
+  omit,
+  isFunction,
+  isEmpty,
+  isEqualByValue,
+} from './utils';
 import { parseInputArgs } from './parseInputArgs';
 import { useInputId } from './useInputId';
 import { useCache } from './useCache';
@@ -245,6 +252,13 @@ export default function useFormState(initialState, options) {
         if (inputOptions.touchOnChange) {
           touch(e);
         }
+
+        const isPristine = isEqualByValue(
+          formState.initialValues.get(name),
+          value,
+        );
+
+        formState.setPristine(isPristine ? omit(name) : { [name]: false });
 
         const partialNewState = { [name]: value };
         const newValues = { ...formState.current.values, ...partialNewState };

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -253,10 +253,15 @@ export default function useFormState(initialState, options) {
           touch(e);
         }
 
-        const isPristine = isEqualByValue(
+        let isPristine;
+        if (isFunction(inputOptions.pristinify)) {
+          isPristine = inputOptions.pristinify(
           formState.initialValues.get(name),
           value,
         );
+        } else {
+          isPristine = isEqualByValue(formState.initialValues.get(name), value);
+        }
 
         formState.setPristine(isPristine ? omit(name) : { [name]: false });
 

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -254,8 +254,8 @@ export default function useFormState(initialState, options) {
         }
 
         let isPristine;
-        if (isFunction(inputOptions.pristinify)) {
-          isPristine = inputOptions.pristinify(
+        if (isFunction(inputOptions.compare)) {
+          isPristine = inputOptions.compare(
           formState.initialValues.get(name),
           value,
         );

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -1,12 +1,5 @@
 import { useRef } from 'react';
-import {
-  toString,
-  noop,
-  omit,
-  isFunction,
-  isEmpty,
-  isEqualByValue,
-} from './utils';
+import { toString, noop, omit, isFunction, isEmpty } from './utils';
 import { parseInputArgs } from './parseInputArgs';
 import { useInputId } from './useInputId';
 import { useCache } from './useCache';

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -256,9 +256,9 @@ export default function useFormState(initialState, options) {
         let isPristine;
         if (isFunction(inputOptions.compare)) {
           isPristine = inputOptions.compare(
-          formState.initialValues.get(name),
-          value,
-        );
+            formState.initialValues.get(name),
+            value,
+          );
         } else {
           isPristine = isEqualByValue(formState.initialValues.get(name), value);
         }

--- a/src/useState.js
+++ b/src/useState.js
@@ -1,5 +1,5 @@
 import { useReducer, useRef } from 'react';
-import { isFunction } from './utils';
+import { isFunction, omit, isEqualByValue } from './utils';
 import { useCache } from './useCache';
 
 function stateReducer(state, newState) {
@@ -13,14 +13,18 @@ export function useState({ initialState, onClear, onReset }) {
   const [touched, setTouched] = useReducer(stateReducer, {});
   const [validity, setValidity] = useReducer(stateReducer, {});
   const [errors, setError] = useReducer(stateReducer, {});
+  const [pristine, setPristine] = useReducer(stateReducer, {});
 
-  state.current = { values, touched, validity, errors };
+  state.current = { values, touched, validity, errors, pristine };
 
   function setField(name, value, inputValidity, inputTouched, inputError) {
     setValues({ [name]: value });
     setTouched({ [name]: inputTouched });
     setValidity({ [name]: inputValidity });
     setError({ [name]: inputError });
+
+    const isPristine = isEqualByValue(initialValues.get(name), value);
+    setPristine(isPristine ? omit(name) : { [name]: false });
   }
 
   const clearField = name => setField(name);
@@ -28,7 +32,7 @@ export function useState({ initialState, onClear, onReset }) {
 
   return {
     /**
-     * @type {{ values, touched, validity, errors }}
+     * @type {{ values, touched, validity, errors, pristine }}
      */
     get current() {
       return state.current;
@@ -37,6 +41,7 @@ export function useState({ initialState, onClear, onReset }) {
     setTouched,
     setValidity,
     setError,
+    setPristine,
     initialValues,
     controls: {
       clearField,

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,16 +65,11 @@ export function isEmpty(value) {
   return false;
 }
 
-// We can have initial values undefined, but input makes them empty strings after edit/clear. We will consider those equal.
+export function isEqualByValue(original, current) {
+  // We can have initial values undefined, but input makes them empty strings
+  // after edit/clear. We will consider those equal.
+  const isNullish =
+    (original === undefined || original === null) && current === '';
 
-const withException = (original, current) =>
-  (original === undefined || original === null) && current === ''
-    ? true
-    : undefined;
-
-function isEqualWith(value, other, customizer) {
-  const result = customizer ? customizer(value, other) : undefined;
-  return result === undefined ? value === other : !!result;
+  return isNullish || original === current;
 }
-
-export const isEqualByValue = (a, b) => isEqualWith(a, b, withException);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,3 @@
-import { isEqualWith } from 'lodash';
-
 /**
  * Returns a function that can be called with an object. The return value of the
  * new function is a copy of the object excluding the key passed initially.
@@ -68,9 +66,23 @@ export function isEmpty(value) {
 }
 
 // We can have initial values undefined, but input makes them empty strings after edit/clear. We will consider those equal.
+
 const withException = (original, current) =>
   (original === undefined || original === null) && current === ''
     ? true
     : undefined;
+
+function baseIsEqual(value, other) {
+  if (value === other) {
+    return true;
+  }
+
+  return false;
+}
+
+function isEqualWith(value, other, customizer) {
+  const result = customizer ? customizer(value, other) : undefined;
+  return result === undefined ? baseIsEqual(value, other) : !!result;
+}
 
 export const isEqualByValue = (a, b) => isEqualWith(a, b, withException);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import { isEqualWith } from 'lodash';
+
 /**
  * Returns a function that can be called with an object. The return value of the
  * new function is a copy of the object excluding the key passed initially.
@@ -64,3 +66,11 @@ export function isEmpty(value) {
   }
   return false;
 }
+
+// We can have initial values undefined, but input makes them empty strings after edit/clear. We will consider those equal.
+const withException = (original, current) =>
+  (original === undefined || original === null) && current === ''
+    ? true
+    : undefined;
+
+export const isEqualByValue = (a, b) => isEqualWith(a, b, withException);

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,17 +72,9 @@ const withException = (original, current) =>
     ? true
     : undefined;
 
-function baseIsEqual(value, other) {
-  if (value === other) {
-    return true;
-  }
-
-  return false;
-}
-
 function isEqualWith(value, other, customizer) {
   const result = customizer ? customizer(value, other) : undefined;
-  return result === undefined ? baseIsEqual(value, other) : !!result;
+  return result === undefined ? value === other : !!result;
 }
 
 export const isEqualByValue = (a, b) => isEqualWith(a, b, withException);

--- a/test/useFormState-pristine.test.js
+++ b/test/useFormState-pristine.test.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { renderWithFormState, renderHook } from './test-utils';
+import { useFormState } from '../src';
+
+describe('useFormState pristine', () => {
+  it('has an pristine object', () => {
+    const { result } = renderHook(() => useFormState());
+    const [formState] = result.current;
+    expect(formState).toHaveProperty('pristine', {});
+  });
+
+  it('marks input as not pristine', () => {
+    const { change, formState } = renderWithFormState(([, { text }]) => (
+      <input {...text({ name: 'name' })} />
+    ));
+    change({ value: 'someval' });
+    expect(formState.current.pristine).toHaveProperty('name', false);
+  });
+
+  it('marks input as not pristine when have default value', () => {
+    const initialData = { name: 'someval' };
+
+    const { change, formState } = renderWithFormState(
+      ([, { text }]) => <input {...text({ name: 'name' })} />,
+      initialData,
+    );
+
+    change({ value: 'someotherval' });
+
+    expect(formState.current.pristine).toHaveProperty('name', false);
+    change({ value: 'someval' });
+
+    expect(formState.current.pristine).not.toHaveProperty('name');
+  });
+
+  it('reset marks input as pristine when have default value', () => {
+    const initialData = { name: 'someval' };
+
+    const { change, formState } = renderWithFormState(
+      ([, { text }]) => <input {...text({ name: 'name' })} />,
+      initialData,
+    );
+    change({ value: 'someotherval' });
+    expect(formState.current.pristine).toHaveProperty('name', false);
+
+    formState.current.resetField('name');
+    expect(formState.current.pristine).not.toHaveProperty('name');
+  });
+
+  it('marks input back as pristine', () => {
+    const { change, formState } = renderWithFormState(([, { text }]) => (
+      <input {...text({ name: 'name' })} />
+    ));
+    change({ value: 'someval' });
+    expect(formState.current.pristine).toHaveProperty('name', false);
+    change({ value: '' });
+    expect(formState.current.pristine).not.toHaveProperty('name');
+  });
+
+  it('handles pristine on raw values', () => {
+    let onChange;
+    const { formState } = renderWithFormState(([, { raw }]) => {
+      const inputProps = raw({ name: 'name' });
+      ({ onChange } = inputProps);
+      return <input {...inputProps} />;
+    });
+
+    onChange({ foo: 'someval' });
+    expect(formState.current.pristine).toHaveProperty('name', false);
+    onChange('');
+    expect(formState.current.pristine).not.toHaveProperty('name');
+  });
+
+  it('handles pristine on raw  default value', () => {
+    const initialData = { name: { foo: 'someval' } };
+
+    let onChange;
+    const { formState } = renderWithFormState(([, { raw }]) => {
+      const inputProps = raw({ name: 'name' });
+      ({ onChange } = inputProps);
+      return <input {...inputProps} />;
+    }, initialData);
+
+    onChange({ foo: 'otherval' });
+    expect(formState.current.pristine).toHaveProperty('name', false);
+    onChange({ foo: 'someval' });
+    expect(formState.current.pristine).not.toHaveProperty('name');
+  });
+
+  it.each([['undefined', undefined], ['empty string', ''], ['null', null]])(
+    'initial value %s is treated as pristine',
+    (name, testValue) => {
+      const initialData = { name: testValue };
+      const { formState, change } = renderWithFormState(
+        ([, { text }]) => <input {...text({ name: 'name' })} />,
+        initialData,
+      );
+      change({ value: 'someval' });
+      expect(formState.current.pristine).toHaveProperty('name');
+      change({ value: '' });
+      expect(formState.current.pristine).not.toHaveProperty('name');
+    },
+  );
+});

--- a/test/useFormState-pristine.test.js
+++ b/test/useFormState-pristine.test.js
@@ -71,13 +71,13 @@ describe('useFormState pristine', () => {
     expect(formState.current.pristine).not.toHaveProperty('name');
   });
 
-  it('calls options.pristinify when an input changes', () => {
-    const pristinifyHandler = jest.fn();
+  it('calls options.compare when an input changes', () => {
+    const compareHandler = jest.fn();
     const { change } = renderWithFormState(([, { text }]) => (
-      <input {...text({ name: 'name', pristinify: pristinifyHandler })} />
+      <input {...text({ name: 'name', compare: compareHandler })} />
     ));
     change({ value: 'someval' });
-    expect(pristinifyHandler).toHaveBeenCalledTimes(1);
+    expect(compareHandler).toHaveBeenCalledTimes(1);
   });
 
   it('handles pristine on raw  default value', () => {
@@ -87,7 +87,7 @@ describe('useFormState pristine', () => {
     const { formState } = renderWithFormState(([, { raw }]) => {
       const inputProps = raw({
         name: 'name',
-        pristinify: (initialValue, value) => isEqual(initialValue, value),
+        compare: (initialValue, value) => isEqual(initialValue, value),
       });
       ({ onChange } = inputProps);
       return <input {...inputProps} />;

--- a/test/useFormState-pristine.test.js
+++ b/test/useFormState-pristine.test.js
@@ -71,12 +71,24 @@ describe('useFormState pristine', () => {
     expect(formState.current.pristine).not.toHaveProperty('name');
   });
 
+  it('calls options.pristinify when an input changes', () => {
+    const pristinifyHandler = jest.fn();
+    const { change } = renderWithFormState(([, { text }]) => (
+      <input {...text({ name: 'name', pristinify: pristinifyHandler })} />
+    ));
+    change({ value: 'someval' });
+    expect(pristinifyHandler).toHaveBeenCalledTimes(1);
+  });
+
   it('handles pristine on raw  default value', () => {
     const initialData = { name: { foo: 'someval' } };
-
+    const isEqual = (a, b) => a.foo === b.foo;
     let onChange;
     const { formState } = renderWithFormState(([, { raw }]) => {
-      const inputProps = raw({ name: 'name' });
+      const inputProps = raw({
+        name: 'name',
+        pristinify: (initialValue, value) => isEqual(initialValue, value),
+      });
       ({ onChange } = inputProps);
       return <input {...inputProps} />;
     }, initialData);

--- a/test/useFormState.test.js
+++ b/test/useFormState.test.js
@@ -10,6 +10,7 @@ describe('useFormState API', () => {
         validity: {},
         touched: {},
         errors: {},
+        pristine: {},
         clear: expect.any(Function),
         reset: expect.any(Function),
         setField: expect.any(Function),


### PR DESCRIPTION
There was a need to disable save button, if there are no actual changes in form.
If user edits input field and changes it back manually: 'car'=>'car2'=>'car'
eg:
```
const isPristine = isEmpty(formState.pristine);
<Button disabled={isPristine} onClick={handleClick}>Save</Button>
```