### PR TITLE
Prep for formOptions.validateOnBlur

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
     - [`formOptions.onTouched`](#formoptionsontouched)
     - [`formOptions.onClear`](#formoptionsonclear)
     - [`formOptions.onReset`](#formoptionsonreset)
+    - [`formOptions.validateOnBlur`](#formoptionsvalidateonblur)
     - [`formOptions.withIds`](#formoptionswithids)
   - [`[formState, inputs]`](#formstate-inputs)
     - [Form State](#form-state)
@@ -551,6 +552,10 @@ const [formState, inputs] = useFormState(null, {
 });
  formState.reset(); // resetting the form state
 ```
+
+#### `formOptions.validateOnBlur`
+
+When set to `true`, all form fields will validated when the input loses focus. If not specified, the `validate` function of each input will be called on value change.
 
 #### `formOptions.withIds`
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -41,6 +41,7 @@ interface FormOptions<T> {
   onClear(): void;
   onReset(): void;
   onTouched(event: React.FocusEvent<InputElement>): void;
+  validateOnBlur: boolean;
   withIds: boolean | ((name: string, value?: string) => string);
 }
 

--- a/src/parseInputArgs.js
+++ b/src/parseInputArgs.js
@@ -4,7 +4,7 @@ const defaultInputOptions = {
   onChange: identity,
   onBlur: noop,
   validate: null,
-  validateOnBlur: false,
+  validateOnBlur: undefined,
   touchOnChange: false,
 };
 

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -251,7 +251,11 @@ export default function useFormState(initialState, options) {
 
         formOptions.onChange(e, formState.current.values, newValues);
 
-        if (!formOptions.validateOnBlur && !inputOptions.validateOnBlur) {
+        const validateOnBlur = formOptions.validateOnBlur
+          ? inputOptions.validateOnBlur !== false
+          : inputOptions.validateOnBlur;
+
+        if (!validateOnBlur) {
           validate(e, value, newValues);
         }
 

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -35,6 +35,7 @@ const [formState, input] = useFormState<FormFields>(initialState, {
     const { name, value } = e.target;
   },
   withIds: (name, value) => (value ? `${name}.${value.toLowerCase()}` : name),
+  validateOnBlur: true,
 });
 
 let name: string = formState.values.name;


### PR DESCRIPTION
Follow up for #110 

- [x] Ability for fields to override global formOptions.validateOnBlur (single field opt-out)
- [x] Update docs
- [x] Types