### PR TITLE
Added a custom props option to the useFormState's options

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,13 +7,13 @@ type StateShape<T> = { [key in keyof T]: any };
 interface UseFormStateHook {
   (
     initialState?: Partial<StateShape<any>> | null,
-    options?: Partial<FormOptions<any>>,
-  ): [FormState<any>, Inputs<any>];
+    options?: Partial<FormOptions<any, {}>>,
+  ): [FormState<any>, Inputs<any, {}>];
 
-  <T extends StateShape<T>, E = StateErrors<T, string>>(
+  <T extends StateShape<T>, E = StateErrors<T, string>, C = {}>(
     initialState?: Partial<T> | null,
-    options?: Partial<FormOptions<T>>,
-  ): [FormState<T, E>, Inputs<T>];
+    options?: Partial<FormOptions<T, C>>,
+  ): [FormState<T, E>, Inputs<T, C>];
 }
 
 export const useFormState: UseFormStateHook;
@@ -31,7 +31,7 @@ interface FormState<T, E = StateErrors<T, string>> {
   resetField(name: keyof T): void;
 }
 
-interface FormOptions<T> {
+interface FormOptions<T, C> {
   onChange(
     event: React.ChangeEvent<InputElement>,
     stateValues: StateValues<T>,
@@ -41,6 +41,7 @@ interface FormOptions<T> {
   onClear(): void;
   onReset(): void;
   onTouched(event: React.FocusEvent<InputElement>): void;
+  customProps(formState: FormState<T>, name: string): C;
   validateOnBlur: boolean;
   withIds: boolean | ((name: string, value?: string) => string);
 }
@@ -61,25 +62,25 @@ type StateErrors<T, E = string> = { readonly [A in keyof T]?: E | string };
 
 // Inputs
 
-interface Inputs<T, Name extends keyof T = keyof T> {
+interface Inputs<T, C extends {}, Name extends keyof T = keyof T> {
   // prettier-ignore
-  selectMultiple: InputInitializer<T, Args<Name>, Omit<BaseInputProps<T>, 'type'> & MultipleProp>;
-  select: InputInitializer<T, Args<Name>, Omit<BaseInputProps<T>, 'type'>>;
-  email: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  color: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  password: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  text: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  textarea: InputInitializer<T, Args<Name>, Omit<BaseInputProps<T>, 'type'>>;
-  url: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  search: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  number: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  range: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  tel: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  radio: InputInitializer<T, Args<Name, OwnValue>, RadioProps<T>>;
-  date: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  month: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  week: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
-  time: InputInitializer<T, Args<Name>, BaseInputProps<T>>;
+  selectMultiple: InputInitializer<T, Args<Name>, Omit<BaseInputProps<T>, 'type'> & MultipleProp & C>;
+  select: InputInitializer<T, Args<Name>, Omit<BaseInputProps<T>, 'type'> & C>;
+  email: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  color: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  password: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  text: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  textarea: InputInitializer<T, Args<Name>, Omit<BaseInputProps<T>, 'type'> & C>;
+  url: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  search: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  number: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  range: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  tel: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  radio: InputInitializer<T, Args<Name, OwnValue>, RadioProps<T> & C>;
+  date: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  month: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  week: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
+  time: InputInitializer<T, Args<Name>, BaseInputProps<T> & C>;
   /**
    * Checkbox inputs with a value will be treated as a collection of choices.
    * Their values in in the form state will be of type Array<string>.
@@ -87,15 +88,15 @@ interface Inputs<T, Name extends keyof T = keyof T> {
    * Checkbox inputs without a value will be treated as toggles. Their values in
    * in the form state will be of type boolean
    */
-  checkbox(name: Name, ownValue?: OwnValue): CheckboxProps<T>;
-  checkbox(options: InputOptions<T, Name, Maybe<OwnValue>>): CheckboxProps<T>;
+  checkbox(name: Name, ownValue?: OwnValue): CheckboxProps<T> & C;
+  checkbox(options: InputOptions<T, Name, Maybe<OwnValue>>): CheckboxProps<T> & C;
 
   raw<RawValue, Name extends keyof T = keyof T>(
     name: Name,
-  ): RawInputProps<T, Name, RawValue>;
+  ): RawInputProps<T, Name, RawValue> & C;
   raw<RawValue, Name extends keyof T = keyof T>(
     options: RawInputOptions<T, Name, RawValue>,
-  ): RawInputProps<T, Name, RawValue>;
+  ): RawInputProps<T, Name, RawValue> & C;
 
   label(name: string, value?: string): LabelProps;
   id(name: string, value?: string): string;

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -24,6 +24,7 @@ const defaultFormOptions = {
   onClear: noop,
   onReset: noop,
   onTouched: noop,
+  customProps: () => ({}),
   withIds: false,
 };
 
@@ -282,13 +283,19 @@ export default function useFormState(initialState, options) {
       ...getIdProp('id', name, ownValue),
     };
 
+    const customProps = formOptions.customProps(formState.current, name);
+
     return isRaw
       ? {
           onChange: inputProps.onChange,
           onBlur: inputProps.onBlur,
           value: inputProps.value,
+          ...customProps
         }
-      : inputProps;
+      : {
+          ...inputProps,
+          ...customProps
+        };
   };
 
   const formStateAPI = useRef({

--- a/test/useFormState-input.test.js
+++ b/test/useFormState-input.test.js
@@ -554,3 +554,30 @@ describe('Input props are memoized', () => {
     expect(renderCheck).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('input type methods return custom props object', () => {
+  /**
+   * Supports customProps
+   */
+  it.each([
+    ...InputTypes.textLike,
+    ...InputTypes.numeric,
+    ...InputTypes.time,
+    'color',
+  ])('returns custom props for type "%s"', type => {
+    const { result } = renderHook(() => useFormState(null, {
+      customProps: (formState, name) => ({
+        isValid: formState.validity[name],
+        errorMessage: formState.errors[name],
+        plainString: "plainString",
+        one: 1
+      })
+    }));
+    expect(result.current[1][type]('input-name')).toEqual(expect.objectContaining({
+      isValid: undefined,
+      errorMessage: undefined,
+      plainString: "plainString",
+      one: 1
+    }));
+  });
+});


### PR DESCRIPTION
To avoid repeating the same piece of code to add validation feedback to an input field I have added in a customProps function to the `formOptions` object to allow the addition of custom props through to your inputs.

My current process is to manually get the errorMessage, validity, and touched from the form state manually for each input like so:

```js
const [formState, inputs] = useFormState();
return (
	<div>
		<Input
			{...inputs.email("email")}
			errorMessage={formState.errors.email}
			isValid={formState.validity.email}
			touched={formState.touched.email}
		/>
		<Input
			{...inputs.email("password")}
			errorMessage={formState.errors.password}
			isValid={formState.validity.password}
			touched={formState.touched.password}
		/>
	</div>
);
```

This is probably not so bad for one or two fields but with a larger form, this would be tedious to manage.

My proposed solution is to be able to configure custom fields that can be defined in the options passed through to useFormState to allow the return type of `inputs[fieldType]()` to match whatever custom element you are passing it through to.

This can be used like so:

```js
const [, inputs] = useFormState(null, {
	customProps: (formState, name) => ({
		isValid: formState.validity[name],
		errorMessage: formState.errors[name],
                placeholder: name,
		otherProp: "otherProp",
	}),
});
console.log(inputs.text("username"));
/*
 * {
 * 	...baseProps,
 * 	isValid: boolean
 * 	errorMessage: string
 *     placeholder: "username"
 * 	otherProp: "otherProp"
 * }
 */
```