### PR TITLE
Pre-release prep for pristine functionality

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,13 @@
       "plugins": ["@babel/plugin-transform-runtime"]
     }
   },
-  "presets": [["@babel/preset-env", { "modules": false }]]
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": false,
+        "exclude": ["transform-typeof-symbol"]
+      }
+    ]
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,15 @@
 {
   "extends": [
+    "@wsmd/eslint-config/typescript",
     "@wsmd/eslint-config/react",
     "@wsmd/eslint-config/prettier",
     "@wsmd/eslint-config/jest"
   ],
   "rules": {
     "getter-return": "off",
-    "consistent-return": "off"
+    "consistent-return": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "no-console": ["error", { "allow": ["warn", "error"] }]
   },
   "overrides": [
     {

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,5 +20,6 @@
         "jsx-a11y/control-has-associated-label": "off"
       }
     }
-  ]
+  ],
+  "ignorePatterns": ["test/types.tsx"]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,12 @@
 {
   "trailingComma": "all",
-  "singleQuote": true
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": ["src/index.d.ts"],
+      "options": {
+        "printWidth": 100
+      }
+    }
+  ]
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,14 +36,6 @@ interface FormState<T, E = StateErrors<T, string>> {
   pristine: { readonly [A in keyof T]: boolean };
   reset(): void;
   clear(): void;
-  setField<K extends keyof T>(field: {
-    name: K;
-    value?: T[K];
-    error?: any;
-    validity?: boolean;
-    touched?: boolean;
-    pristine?: boolean;
-  }): void;
   setField<K extends keyof T>(name: K, value: T[K]): void;
   setFieldError(name: keyof T, error: any): void;
   clearField(name: keyof T): void;

--- a/src/parseInputArgs.js
+++ b/src/parseInputArgs.js
@@ -9,12 +9,10 @@ const defaultInputOptions = {
   compare: null,
 };
 
-export function parseInputArgs(type, args) {
+export function parseInputArgs(args) {
   let name;
   let ownValue;
   let options;
-  let compareFn;
-  let ownCompare;
   if (typeof args[0] === 'string' || typeof args[0] === 'number') {
     [name, ownValue] = args;
   } else {
@@ -26,8 +24,6 @@ export function parseInputArgs(type, args) {
   return {
     name,
     ownValue,
-    compare: compareFn,
-    hasOwnCompare: compareFn === ownCompare,
     hasOwnValue: !!ownValue,
     ...defaultInputOptions,
     ...options,

--- a/src/parseInputArgs.js
+++ b/src/parseInputArgs.js
@@ -1,4 +1,4 @@
-import { identity, noop, isEqualByValue } from './utils';
+import { identity, noop, toString } from './utils';
 
 const defaultInputOptions = {
   onChange: identity,
@@ -6,22 +6,29 @@ const defaultInputOptions = {
   validate: null,
   validateOnBlur: undefined,
   touchOnChange: false,
-  compare: isEqualByValue,
+  compare: null,
 };
 
-export function parseInputArgs(args) {
+export function parseInputArgs(type, args) {
   let name;
   let ownValue;
   let options;
+  let compareFn;
+  let ownCompare;
   if (typeof args[0] === 'string' || typeof args[0] === 'number') {
     [name, ownValue] = args;
   } else {
     [{ name, value: ownValue, ...options }] = args;
   }
 
+  ownValue = toString(ownValue);
+
   return {
     name,
     ownValue,
+    compare: compareFn,
+    hasOwnCompare: compareFn === ownCompare,
+    hasOwnValue: !!ownValue,
     ...defaultInputOptions,
     ...options,
   };

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { noop, omit, isFunction, isEmpty, isEqual } from './utils';
-import { parseInputArgs as getInputOptions } from './parseInputArgs';
+import { parseInputArgs } from './parseInputArgs';
 import { useInputId } from './useInputId';
 import { useCache } from './useCache';
 import { useState } from './useState';
@@ -44,8 +44,7 @@ export default function useFormState(initialState, options) {
   }
 
   const createPropsGetter = type => (...args) => {
-    const { name, ownValue, hasOwnValue, ...inputOptions } = getInputOptions(
-      type,
+    const { name, ownValue, hasOwnValue, ...inputOptions } = parseInputArgs(
       args,
     );
 
@@ -65,7 +64,7 @@ export default function useFormState(initialState, options) {
     function setDefaultValue() {
       /* istanbul ignore else */
       if (process.env.NODE_ENV === 'development') {
-        if (isRaw && !hasValueInState) {
+        if (isRaw) {
           warn(
             key,
             'missingInitialValue',
@@ -191,7 +190,7 @@ export default function useFormState(initialState, options) {
           return values[name] === ownValue;
         }
         if (isCheckbox) {
-          if (!ownValue) {
+          if (!hasOwnValue) {
             return values[name] || false;
           }
           /**

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
-import { toString, noop, omit, isFunction, isEmpty } from './utils';
-import { parseInputArgs } from './parseInputArgs';
+import { noop, omit, isFunction, isEmpty, isEqual } from './utils';
+import { parseInputArgs as getInputOptions } from './parseInputArgs';
 import { useInputId } from './useInputId';
 import { useCache } from './useCache';
 import { useState } from './useState';
@@ -39,15 +39,16 @@ export default function useFormState(initialState, options) {
   function warn(key, type, message) {
     if (!devWarnings.has(`${type}:${key}`)) {
       devWarnings.set(`${type}:${key}`, true);
-      // eslint-disable-next-line no-console
       console.warn(CONSOLE_TAG, message);
     }
   }
 
   const createPropsGetter = type => (...args) => {
-    const { name, ownValue, ...inputOptions } = parseInputArgs(args);
+    const { name, ownValue, hasOwnValue, ...inputOptions } = getInputOptions(
+      type,
+      args,
+    );
 
-    const hasOwnValue = !!toString(ownValue);
     const isCheckbox = type === CHECKBOX;
     const isRadio = type === RADIO;
     const isSelectMultiple = type === SELECT_MULTIPLE;
@@ -55,16 +56,16 @@ export default function useFormState(initialState, options) {
     const hasValueInState = formState.current.values[name] !== undefined;
 
     // This is used to cache input props that shouldn't change across
-    // re-renders.  Note that for `raw` values, `toString(ownValue)`
+    // re-renders.  Note that for `raw` values, `ownValue`
     // will return '[object Object]'.  This means we can't have multiple
     // raw inputs with the same name and different values, but this is
     // probably fine.
-    const key = `${type}.${name}.${toString(ownValue)}`;
+    const key = `${type}.${name}.${ownValue}`;
 
     function setDefaultValue() {
       /* istanbul ignore else */
       if (process.env.NODE_ENV === 'development') {
-        if (isRaw && formState.current.values[name] === undefined) {
+        if (isRaw && !hasValueInState) {
           warn(
             key,
             'missingInitialValue',
@@ -110,6 +111,28 @@ export default function useFormState(initialState, options) {
           option.selected ? [...values, option.value] : values,
         [],
       );
+    }
+
+    function getCompareFn() {
+      if (isFunction(inputOptions.compare)) {
+        return inputOptions.compare;
+      }
+      if (isRaw) {
+        /* istanbul ignore else */
+        if (process.env.NODE_ENV === 'development') {
+          warn(
+            key,
+            'missingCompare',
+            `You used a raw input type for "${name}" without providing a ` +
+              'custom compare method. As a result, the pristine value of ' +
+              'this input will remain set to "false" after a change. If the ' +
+              'form depends on the pristine values, please provide a custom ' +
+              'compare method.',
+          );
+        }
+        return () => false;
+      }
+      return isEqual;
     }
 
     function validate(
@@ -165,10 +188,10 @@ export default function useFormState(initialState, options) {
       get checked() {
         const { values } = formState.current;
         if (isRadio) {
-          return values[name] === toString(ownValue);
+          return values[name] === ownValue;
         }
         if (isCheckbox) {
-          if (!hasOwnValue) {
+          if (!ownValue) {
             return values[name] || false;
           }
           /**
@@ -177,9 +200,7 @@ export default function useFormState(initialState, options) {
            * <input {...input.checkbox('option1')} />
            * <input {...input.checkbox('option1', 'value_of_option1')} />
            */
-          return hasValueInState
-            ? values[name].includes(toString(ownValue))
-            : false;
+          return hasValueInState ? values[name].includes(ownValue) : false;
         }
       },
       get value() {
@@ -196,13 +217,18 @@ export default function useFormState(initialState, options) {
           formState.setTouched({ [name]: false });
         }
 
+        // auto populating default values of pristine
+        if (formState.current.pristine[name] == null) {
+          formState.setPristine({ [name]: true });
+        }
+
         /**
          * Since checkbox and radio inputs have their own user-defined values,
          * and since checkbox inputs can be either an array or a boolean,
          * returning the value of input from the current form state is illogical
          */
         if (isCheckbox || isRadio) {
-          return toString(ownValue);
+          return ownValue;
         }
 
         return hasValueInState ? formState.current.values[name] : '';
@@ -247,13 +273,6 @@ export default function useFormState(initialState, options) {
           touch(e);
         }
 
-        const isPristine = inputOptions.compare(
-          formState.initialValues.get(name),
-          value,
-        );
-
-        formState.setPristine(isPristine ? omit(name) : { [name]: false });
-
         const partialNewState = { [name]: value };
         const newValues = { ...formState.current.values, ...partialNewState };
 
@@ -266,6 +285,8 @@ export default function useFormState(initialState, options) {
         if (!validateOnBlur) {
           validate(e, value, newValues);
         }
+
+        formState.updatePristine(name, value, getCompareFn());
 
         formState.setValues(partialNewState);
       }),
@@ -299,11 +320,10 @@ export default function useFormState(initialState, options) {
   };
 
   const formStateAPI = useRef({
+    isPristine: formState.isPristine,
     clearField: formState.clearField,
     resetField: formState.resetField,
-    setField(name, value) {
-      formState.setField(name, value, true, true);
-    },
+    setField: formState.setField,
     setFieldError(name, error) {
       formState.setValidity({ [name]: false });
       formState.setError({ [name]: error });

--- a/src/useState.js
+++ b/src/useState.js
@@ -20,7 +20,7 @@ export function useState({ initialState }) {
   function getInitialValue(name) {
     return initialValues.has(name)
       ? initialValues.get(name)
-      : initialState[name];
+      : getOr(initialState, state.current.values)[name];
   }
 
   function updatePristine(name, value, comparator) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,11 +65,17 @@ export function isEmpty(value) {
   return false;
 }
 
-export function isEqualByValue(original, current) {
-  // We can have initial values undefined, but input makes them empty strings
-  // after edit/clear. We will consider those equal.
-  const isNullish =
-    (original === undefined || original === null) && current === '';
+export function isEqual(value, other) {
+  if (Array.isArray(value) && Array.isArray(other)) {
+    return (
+      value.length === other.length &&
+      value.every(a => other.indexOf(a) > -1) &&
+      other.every(b => value.indexOf(b) > -1)
+    );
+  }
+  return value === other;
+}
 
-  return isNullish || original === current;
+export function getOr(value, fallback) {
+  return value != null ? value : fallback;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,13 @@ export function isEqual(value, other) {
   return value === other;
 }
 
-export function getOr(value, fallback) {
-  return value != null ? value : fallback;
+export function testIsEqualCompatibility(value) {
+  let result;
+  /* istanbul ignore if */
+  if (Array.isArray(value)) {
+    result = value.every(testIsEqualCompatibility);
+  } else {
+    result = value == null || /^[sbn]/.test(typeof value); // is primitive
+  }
+  return result;
 }

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -285,13 +285,3 @@ function PropsDelegation() {
   const [formState, input] = useFormState<FormFields>();
   return <Input formState={formState} {...input.email('email')} />;
 }
-
-formState.setField('colors', ['red']);
-formState.setField({
-  name: 'colors',
-  value: ['red'],
-  error: 'invalid',
-  pristine: true,
-  validity: false,
-  touched: false,
-});

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -285,3 +285,13 @@ function PropsDelegation() {
   const [formState, input] = useFormState<FormFields>();
   return <Input formState={formState} {...input.email('email')} />;
 }
+
+formState.setField('colors', ['red']);
+formState.setField({
+  name: 'colors',
+  value: ['red'],
+  error: 'invalid',
+  pristine: true,
+  validity: false,
+  touched: false,
+});

--- a/test/useFormState-pristine.test.js
+++ b/test/useFormState-pristine.test.js
@@ -110,9 +110,10 @@ describe('useFormState pristine', () => {
   });
 
   it('handles pristine of checkbox inputs', () => {
+    const initialState = { permission: ['1', '2', '4'] };
     const { formState, click } = renderWithFormState(
-      ([, { checkbox }]) => <input {...checkbox('permission', 1)} />,
-      { permission: [1, 2, 4] },
+      ([, { checkbox }]) => <input {...checkbox('permission', '1')} />,
+      initialState,
     );
     expect(formState.current.pristine).toHaveProperty('permission', true);
     click();

--- a/test/useFormState.test.js
+++ b/test/useFormState.test.js
@@ -17,6 +17,7 @@ describe('useFormState API', () => {
         setFieldError: expect.any(Function),
         clearField: expect.any(Function),
         resetField: expect.any(Function),
+        isPristine: expect.any(Function),
       },
       expect.any(Object),
     ]);


### PR DESCRIPTION
This a pre-release follow up PR for #109 

### Added

#### Ability to check whether the entire form is pristine

The form-state object now exposes an `isPrisitine(): boolean` function 

```tsx
const [formState, input] = useFormState();

<button disabled={formState.isPristine()}>
  Submit
</button>
```

#### Development warning for `isRaw` when a `compare` function is missing

Using `isEqualByValue` (strict equality check) as a default compare function for `raw` inputs is probably not a good idea since these inputs tend to have objects as their values. When a custom compare method is missing on a `raw` input, a warning will be logged in development.

#### Added missing types for pristine functionality

Added missing types for `formState.prisitne`, `formState.isPrisitne()`, and `formOptions.compare()`

### Changed

#### Initial pristine value for all inputs is `true` (as opposed to `undefined` in #109)

```js
// on mount
{
  values: {
    foo: '',
    bar: '',
    baz: '',
  },
  pristine: {
    foo: true,
    bar: true,
    baz: true,
  },
  // ...
}
```

#### Ability to manually update the entire state of a field (value, error, validity, pristine, etc..)

In #109, `resetField` was always using `isEqualByValue` as a comparator (via `setField`) even when a custom compare function is set on an input. `setField` does not have access to the input context (options of an individual input), and therefore, `setField` now accepts all values to be provided manually.

```js
// previously (still possible) 
formState.setField('my-input', 'custom value');

// alternate API
formState.setField({
  name: 'my-input',
  value: 'custom value',
  validity: false,
  pristine: false,
  error: 'invalid input!',
});
```

For consistency, and similar to `validity`, the `pristine` value of an input will be explicitly set to `true` when `setField`/`resetField` is called skipping any comparisons (unless specified otherwise via the function above).

### Fixed

#### Incorrect pristine value for `checkbox` inputs

The value of checkbox inputs can be an array and this library should support that by default. The original `isEqualByValue` wasn't sufficient for this case since it was doing strict equality check.
