### PR TITLE
Allow TypeScript to infer form shape from initial state

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,11 +16,7 @@ type StateErrors<T, E = string> = {
 };
 
 interface UseFormStateHook {
-  (initialState?: Partial<StateShape<any>> | null, options?: FormOptions<any>): [
-    FormState<any>,
-    Inputs<any>,
-  ];
-  <T extends StateShape<T>, E = StateErrors<T, string>>(
+  <T extends StateShape<T> = StateShape<any>, E = StateErrors<T, string>>(
     initialState?: Partial<T> | null,
     options?: FormOptions<T>,
   ): [FormState<T, E>, Inputs<T>];
@@ -86,16 +82,22 @@ interface Inputs<T> {
 interface InputInitializer<T, InputProps> {
   <K extends keyof T>(options: InputOptions<T, K>): InputProps;
   <K extends keyof T>(name: K): InputProps;
+  (options: InputOptions<any, string>): InputProps;
+  (name: string): InputProps;
 }
 
 interface InputInitializerWithOwnValue<T, R> {
   <K extends keyof T>(options: InputOptions<T, K, { value: OwnValueType }>): R;
   <K extends keyof T>(name: K, value: OwnValueType): R;
+  (options: InputOptions<any, string, { value: OwnValueType }>): R;
+  (name: string, value: OwnValueType): R;
 }
 
 interface InputInitializerWithOptionalOwnValue<T, R> {
   <K extends keyof T>(options: InputOptions<T, K, { value?: OwnValueType }>): R;
   <K extends keyof T>(name: K, value?: OwnValueType): R;
+  (options: InputOptions<any, string, { value?: OwnValueType }>): R;
+  (name: string, value?: OwnValueType): R;
 }
 
 interface RawInputInitializer<T> {
@@ -103,6 +105,8 @@ interface RawInputInitializer<T> {
     options: RawInputOptions<T, K, RawValue>,
   ): RawInputProps<T, K, RawValue>;
   <RawValue extends any, K extends keyof T = keyof T>(name: K): RawInputProps<T, K, RawValue>;
+  (options: RawInputOptions<any, string, any>): RawInputProps<any, string, any>;
+  (name: string): RawInputProps<any, string, any>;
 }
 
 type InputOptions<T, K extends keyof T, OwnOptions = {}> = {


### PR DESCRIPTION
Remove unneeded signature for `useFormState` and makes the generic signature form shape default to `StateShape<any>`.

This allows the TypeScript compiler to infer the form shape form the initial values, which allows for strongly typed forms, without having to create a new interface and pass it in the generic signature.

before: 
![image](https://user-images.githubusercontent.com/1560696/111542691-f95efd80-8769-11eb-8c86-bb8abd2b8851.png)

after:
![image](https://user-images.githubusercontent.com/1560696/111542758-0c71cd80-876a-11eb-90eb-dc9360446905.png)
